### PR TITLE
test: Add comprehensive exportImport tests (Phase 2)

### DIFF
--- a/docs/plans/automated-testing-implementation-plan.md
+++ b/docs/plans/automated-testing-implementation-plan.md
@@ -227,7 +227,7 @@ Day 1 (PR 1): ✅ COMPLETE
   → PR #33
 
 Day 2 (PR 2): ✅ COMPLETE
-  [x] 2.2 exportImport.test.ts (85 tests)
+  [x] 2.2 exportImport.test.ts (94 tests)
   → PR #34
 
 Day 3-4 (PR 3):
@@ -264,7 +264,7 @@ Day 8-9 (PR 6):
 | `src/test/factories.ts` | Factory | - | ✅ |
 | `src/test/test-utils.tsx` | Utility | - | ✅ |
 | `src/utils/temporalGrouping.test.ts` | Unit | 35 | ✅ |
-| `src/utils/exportImport.test.ts` | Unit | 85 | ✅ |
+| `src/utils/exportImport.test.ts` | Unit | 94 | ✅ |
 | `src/services/tags.test.ts` | Unit | 30 | |
 | `src/services/notes.test.ts` | Unit | 60 | |
 | `src/components/TagModal.test.tsx` | Integration | 12 | |
@@ -283,7 +283,7 @@ Day 8-9 (PR 6):
 | `e2e/settings.spec.ts` | E2E | 3 | |
 
 **Total: 21 new files, ~268 new tests**
-**Progress: 5 files created, 120 tests written**
+**Progress: 5 files created, 129 tests written**
 
 ---
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -72,6 +72,12 @@ Object.defineProperty(navigator, 'clipboard', {
   configurable: true,
 });
 
+// Mock ClipboardItem for rich clipboard operations
+class MockClipboardItem {
+  constructor(public data: Record<string, Blob>) {}
+}
+global.ClipboardItem = MockClipboardItem as unknown as typeof ClipboardItem;
+
 // Mock window.matchMedia (for theme detection and responsive tests)
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary

Phase 2 of the automated testing implementation plan. Adds comprehensive tests for all export/import utility functions.

### New Tests (85 tests)

| Function/Group | Tests | Description |
|----------------|-------|-------------|
| `ValidationError` | 2 | Error class instantiation |
| `exportNotesToJSON` | 5 | Structure, metadata, tags export |
| `parseImportedJSON` | 16 | Validation, edge cases, truncation, error handling |
| `htmlToMarkdown` | 14 | Headers, lists, code blocks, task lists, entities |
| `markdownToHtml` | 11 | Reverse conversion, HTML escaping |
| `parseMultiNoteMarkdown` | 7 | Single/multiple notes, tags parsing |
| `exportNoteToJSON` | 2 | Single note JSON export |
| `exportNoteToMarkdown` | 4 | Single note markdown export |
| `getSanitizedFilename` | 6 | Special chars, length, edge cases |
| `formatNoteForClipboard` | 4 | Plain text formatting |
| `formatNoteForClipboardHtml` | 3 | HTML formatting |
| `htmlToPlainText` | 6 | HTML to text with list/quote handling |
| `copyNoteToClipboard` | 1 | Clipboard writeText |
| `copyNoteWithFormatting` | 1 | ClipboardItem API |
| `downloadFile` | 1 | Blob URL creation |
| Constants | 3 | MAX_IMPORT_NOTES, MAX_TITLE_LENGTH, etc. |

## Test Plan
- [x] `npm run check` passes (typecheck + lint + test + build)
- [x] All 163 tests pass (85 new + 78 existing)

## Related
- Implementation Plan: `docs/plans/automated-testing-implementation-plan.md`
- Phase 1 PR: #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)