### PR TITLE
🛡️ Sentinel: Enforce content sanitization in note services

### DIFF
--- a/src/services/notes.ts
+++ b/src/services/notes.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { supabase } from '../lib/supabase';
+import { sanitizeHtml } from '../utils/sanitize';
 import type { Note, Tag, TagColor, NoteShare } from '../types';
 import type { DbNote, DbTag, DbNoteShare } from '../types/database';
 
@@ -85,7 +86,7 @@ export async function createNote(
   } = {
     user_id: userId,
     title,
-    content,
+    content: sanitizeHtml(content),
   };
 
   // Preserve original timestamps if provided (e.g., during import)
@@ -143,7 +144,7 @@ export async function createNotesBatch(
       } = {
         user_id: userId,
         title: note.title,
-        content: note.content,
+        content: sanitizeHtml(note.content),
       };
 
       if (note.createdAt) {
@@ -184,7 +185,7 @@ export async function updateNote(note: Note): Promise<Note> {
     .from('notes')
     .update({
       title: note.title,
-      content: note.content,
+      content: sanitizeHtml(note.content),
       updated_at: new Date().toISOString(),
     })
     .eq('id', note.id)


### PR DESCRIPTION
🛡️ Sentinel: Enforce content sanitization in note services

**Vulnerability:**
Notes content (HTML) was being saved to the database (Supabase) and local storage (IndexedDB) without sanitization in the service layer. While the frontend (`App.tsx`) was performing some sanitization, relying solely on the frontend is a security risk (defense in depth). A malicious payload could be injected if the frontend sanitization was bypassed or if the API was called directly.

**Fix:**
Enforced sanitization using `sanitizeHtml` (DOMPurify) in:
- `src/services/notes.ts` (Direct Supabase operations)
- `src/services/offlineNotes.ts` (Offline-first operations)

This ensures that all notes are sanitized before persistence, regardless of where the call originates.

**Verification:**
Added a test case in `src/services/notes_security.test.ts` that attempts to create a note with a `<script>` tag. The test asserts that the script tag is stripped before the insert operation.

Running `pnpm test src/services/notes_security.test.ts` passes.
Running `pnpm test` confirms no regressions.

---
*PR created automatically by Jules for task [751524440302762195](https://jules.google.com/task/751524440302762195) started by @anbuneel*