### PR TITLE
Shield: Add input validation and sanitization for notes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+## Sentinel Journal
+
+## 2025-02-18 - Input Validation Gap in Notes Service
+**Vulnerability:** The notes service (`createNote`, `updateNote`) accepted arbitrary length strings and raw HTML without validation, relying solely on frontend display-time sanitization.
+**Learning:** While display-time sanitization (DOMPurify in `NoteCard`) prevents XSS for the current client, the lack of input validation allowed:
+1. Potential DoS via massive payloads (e.g. 100MB strings).
+2. Stored XSS risks if data is ever consumed by other clients (e.g. admin dashboard, mobile app) that assume trusted DB content.
+**Prevention:** Enforce input validation (length limits) and sanitization (HTML stripping/cleaning) at the service layer (boundary) before persistence, ensuring "defense in depth".

--- a/src/services/notes.ts
+++ b/src/services/notes.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { supabase } from '../lib/supabase';
+import { validateNoteTitle, validateNoteContent } from '../utils/validation';
 import type { Note, Tag, TagColor, NoteShare } from '../types';
 import type { DbNote, DbTag, DbNoteShare } from '../types/database';
 
@@ -84,8 +85,8 @@ export async function createNote(
     updated_at?: string;
   } = {
     user_id: userId,
-    title,
-    content,
+    title: validateNoteTitle(title),
+    content: validateNoteContent(content),
   };
 
   // Preserve original timestamps if provided (e.g., during import)
@@ -142,8 +143,8 @@ export async function createNotesBatch(
         updated_at?: string;
       } = {
         user_id: userId,
-        title: note.title,
-        content: note.content,
+        title: validateNoteTitle(note.title),
+        content: validateNoteContent(note.content),
       };
 
       if (note.createdAt) {
@@ -183,8 +184,8 @@ export async function updateNote(note: Note): Promise<Note> {
   const { data, error } = await supabase
     .from('notes')
     .update({
-      title: note.title,
-      content: note.content,
+      title: validateNoteTitle(note.title),
+      content: validateNoteContent(note.content),
       updated_at: new Date().toISOString(),
     })
     .eq('id', note.id)

--- a/src/services/notes_input_validation.test.ts
+++ b/src/services/notes_input_validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createNote } from './notes';
+import { createMockQueryBuilder, type MockQueryBuilder } from '../test/factories';
+import { supabase } from '../lib/supabase';
+
+// Mock supabase
+vi.mock('../lib/supabase', () => {
+  return {
+    supabase: {
+      from: vi.fn(() => createMockQueryBuilder()),
+    },
+  };
+});
+
+// Helper for mocking
+function mockSupabaseFrom(builder: MockQueryBuilder): void {
+  vi.mocked(supabase.from).mockReturnValue(builder);
+}
+
+describe('Notes Input Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects overly long titles', async () => {
+    const longTitle = 'a'.repeat(201); // 200 limit
+    const mockBuilder = createMockQueryBuilder();
+    mockSupabaseFrom(mockBuilder);
+
+    await expect(createNote('user-1', longTitle, 'content'))
+      .rejects.toThrow(/title/i);
+  });
+
+  it('rejects overly long content', async () => {
+    const longContent = 'a'.repeat(500001); // 500KB limit
+    const mockBuilder = createMockQueryBuilder();
+    mockSupabaseFrom(mockBuilder);
+
+    await expect(createNote('user-1', 'Title', longContent))
+      .rejects.toThrow(/content/i);
+  });
+
+  it('sanitizes content before storage', async () => {
+    const maliciousContent = '<script>alert(1)</script><p>Safe</p>';
+    const mockBuilder = createMockQueryBuilder({
+       singleResult: {
+         data: { id: '1', user_id: '1', title: 'T', content: '<p>Safe</p>', created_at: '', updated_at: '' },
+         error: null
+       }
+    });
+    mockSupabaseFrom(mockBuilder);
+
+    await createNote('user-1', 'Title', maliciousContent);
+
+    // Verify insert was called with SANITIZED content
+    expect(mockBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.not.stringContaining('<script>'),
+      })
+    );
+
+    expect(mockBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('<p>Safe</p>'),
+      })
+    );
+  });
+
+  it('strips HTML from title before storage', async () => {
+    const htmlTitle = '<b>Bold</b> & <script>alert(1)</script>';
+    const mockBuilder = createMockQueryBuilder({
+       singleResult: {
+         data: { id: '1', user_id: '1', title: 'Bold & ', content: '', created_at: '', updated_at: '' },
+         error: null
+       }
+    });
+    mockSupabaseFrom(mockBuilder);
+
+    await createNote('user-1', htmlTitle, 'content');
+
+    // Should strip tags but keep text
+    expect(mockBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.not.stringContaining('<b>'),
+      })
+    );
+    expect(mockBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.not.stringContaining('<script>'),
+      })
+    );
+    // Note: htmlToPlainText decodes entities, so & may remain &
+    expect(mockBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringMatching(/Bold\s*&\s*/),
+      })
+    );
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,43 @@
+import { sanitizeHtml, htmlToPlainText } from './sanitize';
+
+// Constants
+export const MAX_NOTE_TITLE_LENGTH = 200;
+export const MAX_NOTE_CONTENT_LENGTH = 500000; // ~500KB
+
+/**
+ * Validate and sanitize note title.
+ * - Trims whitespace
+ * - Checks length
+ * - Strips HTML tags (returns plain text)
+ */
+export function validateNoteTitle(title: string): string {
+  if (!title) return '';
+
+  const trimmed = title.trim();
+
+  if (trimmed.length > MAX_NOTE_TITLE_LENGTH) {
+    throw new Error(`Title must be less than ${MAX_NOTE_TITLE_LENGTH} characters`);
+  }
+
+  // Strip HTML tags to ensure title is plain text
+  // We don't escape entities here to avoid double-escaping on display
+  // (Display components usually handle escaping or sanitization)
+  return htmlToPlainText(trimmed);
+}
+
+/**
+ * Validate and sanitize note content.
+ * - Checks length
+ * - Sanitizes HTML (removes dangerous tags like <script>)
+ */
+export function validateNoteContent(content: string): string {
+  if (!content) return '';
+
+  if (content.length > MAX_NOTE_CONTENT_LENGTH) {
+    throw new Error(`Content must be less than ${MAX_NOTE_CONTENT_LENGTH} characters`);
+  }
+
+  // Sanitize HTML to prevent XSS (Stored XSS)
+  // This allows safe tags (p, b, i, lists) but strips scripts/iframes
+  return sanitizeHtml(content);
+}


### PR DESCRIPTION
This change enhances security by adding input validation and sanitization to the notes service.
Previously, the service accepted arbitrary length strings and raw HTML, relying only on frontend sanitization.
This change enforces "defense in depth" by:
1. Limiting note title to 200 characters and content to 500,000 characters to prevent DoS.
2. Sanitizing HTML content on input to prevent Stored XSS in the database.
3. Stripping HTML tags from titles on input to ensure they remain plain text.

Verification:
- New tests in `src/services/notes_input_validation.test.ts` pass.
- Existing tests pass.
- Validated that `offlineNotes.ts` also uses the same validation logic.

---
*PR created automatically by Jules for task [10941455928455649851](https://jules.google.com/task/10941455928455649851) started by @anbuneel*