### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Missing rel="noopener noreferrer" in Sanitization
+**Vulnerability:** User-generated content with `target="_blank"` links lacked `rel="noopener noreferrer"`, exposing the app to reverse tabnabbing attacks where the new page can manipulate the original page.
+**Learning:** `DOMPurify` configuration `ADD_ATTR` only allows attributes but does not enforce values. Hooks like `afterSanitizeAttributes` are required to enforce security attributes.
+**Prevention:** Registered a global `DOMPurify` hook in `src/utils/sanitize.ts` to automatically add `rel="noopener noreferrer"` to all external links.

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,12 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" for links with target="_blank"
+// This prevents reverse tabnabbing attacks where the opened page can manipulate the original page
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if ('target' in node && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: User-generated content containing links with `target="_blank"` was missing the `rel="noopener noreferrer"` attribute. This allows the opened page to access `window.opener` and potentially redirect the original page to a malicious site (Reverse Tabnabbing).
🎯 Impact: Users clicking on shared notes or external links could be victims of phishing attacks if the destination site is malicious.
🔧 Fix: Implemented a global `DOMPurify` hook in `src/utils/sanitize.ts` that intercepts all anchor tags during sanitization. If `target="_blank"` is detected, it enforces `rel="noopener noreferrer"`.
✅ Verification: Added a regression test in `src/utils/sanitize.test.ts` ensuring that `<a href="..." target="_blank">` is transformed to include the secure `rel` attribute. Validated with `npm run test`.

---
*PR created automatically by Jules for task [8400702661819274886](https://jules.google.com/task/8400702661819274886) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
