### PR TITLE
⚡ Bolt: Memoize ChapterSection to reduce re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [ChapterSection Memoization]
+**Learning:** `App.tsx` recreates handlers (`onNoteClick`, etc.) and data structures (`chapters` via `groupNotesByChapter`) on every render. This causes `ChapterSection` to re-render constantly even if note content is unchanged, triggering expensive `Masonry` layouts.
+**Action:** Use `React.memo` with a custom comparison function in `ChapterSection` to check for shallow note equality and ignore unstable handler props. This avoids re-renders when `App` updates unrelated state (like search query typing).


### PR DESCRIPTION
💡 What: Memoized `ChapterSection` with a custom comparison function that checks note content equality and ignores unstable handlers.
🎯 Why: `App` re-renders (e.g. during search typing) cause all `ChapterSection`s to re-render because `notes` array references change (due to grouping logic) and handlers are unstable. This triggered expensive `Masonry` layout calculations and VDOM diffing even for unchanged chapters.
📊 Impact: Prevents re-rendering of all note lists when interacting with the app (e.g. typing in search, toggling unrelated state), improving responsiveness.
🔬 Measurement: Verified that `ChapterSection` memoization logic correctly handles note array updates and ignores function prop changes. Tests passed.

---
*PR created automatically by Jules for task [1331948951875934649](https://jules.google.com/task/1331948951875934649) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
