### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-01 - Reverse Tabnabbing in Sanitized HTML
+**Vulnerability:** User-generated content with `target="_blank"` links did not enforce `rel="noopener noreferrer"`, allowing opened pages to control the parent window (Reverse Tabnabbing).
+**Learning:** `DOMPurify` does not automatically add `rel="noopener noreferrer"` to `target="_blank"` links by default; it requires an explicit hook. `sanitizeHtml` was allowing `target` but missing the corresponding safety attribute.
+**Prevention:** Always register a `DOMPurify` hook to enforce `rel="noopener noreferrer"` whenever `target="_blank"` is allowed in user content.

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add hook to enforce noopener noreferrer for target="_blank" to prevent reverse tabnabbing
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // Check if it's an anchor tag and has target="_blank"
+  if ('target' in node && node.getAttribute('target')?.toLowerCase() === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: User-generated content with `target="_blank"` links allowed opening new tabs without `rel="noopener noreferrer"`. This could allow a malicious linked page to hijack the parent page (Reverse Tabnabbing).
🎯 Impact: If a user clicks a malicious link in a shared note, the attacker could redirect the Yidhan app to a phishing site.
🔧 Fix: Added a global `DOMPurify` hook in `src/utils/sanitize.ts` that detects `target="_blank"` on anchor tags and enforces `rel="noopener noreferrer"`.
✅ Verification: Verified with a test case that confirms `rel="noopener noreferrer"` is added to vulnerable links and that malicious `rel` attributes are overwritten. Existing tests passed with no regressions.

---
*PR created automatically by Jules for task [6776314392851067830](https://jules.google.com/task/6776314392851067830) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
