### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-21 - [DOMPurify Hooks for Security]
+**Vulnerability:** Reverse Tabnabbing via `target="_blank"` links in user content.
+**Learning:** `DOMPurify` by default allows `target="_blank"` without adding `rel="noopener noreferrer"`, leaving users vulnerable to phishing via tabnabbing.
+**Prevention:** Use `DOMPurify.addHook('afterSanitizeAttributes', ...)` to programmatically enforce `rel="noopener noreferrer"` on all `<a>` tags with `target="_blank"`, overwriting any user input.

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,26 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('should add rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    // Also check that it preserves the target
+    expect(output).toContain('target="_blank"');
+  });
+
+  it('should not allow malicious rel attributes', () => {
+     // If the user tries to overwrite it or add something else
+     const input = '<a href="https://example.com" target="_blank" rel="opener">Link</a>';
+     const output = sanitizeHtml(input);
+     // We want to ensure noopener noreferrer is present
+     expect(output).toContain('noreferrer');
+     // And prevent standalone "opener" or "rel=\"opener\""
+     // Note: "noopener" contains "opener" substring, so we check for exact attribute or surrounding spaces
+     expect(output).not.toContain('rel="opener"');
+     expect(output).toContain('rel="noopener noreferrer"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,17 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce security on links
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // Check if it's a link
+  if ('target' in node && node.tagName === 'A') {
+    const target = node.getAttribute('target');
+    // If opening in a new tab, strictly enforce noopener noreferrer
+    if (target === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Links with `target="_blank"` (external links) were not strictly enforcing `rel="noopener noreferrer"`. This allowed potential reverse tabnabbing attacks where a linked malicious page could manipulate the `window.opener` object to redirect the user's previous tab to a phishing site.
🎯 Impact: Users clicking on shared links or external links in notes could be victims of phishing if the link target is malicious.
🔧 Fix: Added a global `DOMPurify` hook in `src/utils/sanitize.ts` that intercepts all `<a>` tags during sanitization. If `target="_blank"` is detected, it forcibly sets `rel="noopener noreferrer"`, overwriting any unsafe values (like `rel="opener"`).
✅ Verification: Added new unit tests in `src/utils/sanitize.test.ts` that confirm:
  1. `rel="noopener noreferrer"` is automatically added to `target="_blank"` links.
  2. Malicious attributes like `rel="opener"` are successfully overwritten.

---
*PR created automatically by Jules for task [6249211138322448429](https://jules.google.com/task/6249211138322448429) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
