### PR TITLE
🛡️ Sentinel: Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-04 - Reverse Tabnabbing Protection
+**Vulnerability:** Links with `target="_blank"` were vulnerable to reverse tabnabbing (phishing via `window.opener`).
+**Learning:** `DOMPurify` configuration alone (`ALLOWED_ATTR`) is insufficient to enforce attributes; hooks are required.
+**Prevention:** Use `DOMPurify.addHook('afterSanitizeAttributes', ...)` to enforce `rel="noopener noreferrer"`.

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,19 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    expect(output).toContain('target="_blank"');
+  });
+
+  it('does not add rel attribute to links without target="_blank"', () => {
+    const input = '<a href="https://example.com">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).not.toContain('rel="noopener noreferrer"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" for links with target="_blank"
+// This prevents reverse tabnabbing attacks
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if ('target' in node && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Links with `target="_blank"` allows the opened page to access `window.opener` of the original page, which can be used for phishing attacks (Reverse Tabnabbing).
🎯 Impact: Users clicking on user-generated links could be redirected to malicious sites on the original tab without their knowledge.
🔧 Fix: Implemented a global `DOMPurify` hook that enforces `rel="noopener noreferrer"` on all links with `target="_blank"`.
✅ Verification: Added unit tests in `src/utils/sanitize.test.ts` to confirm the attribute is correctly added.

---
*PR created automatically by Jules for task [15389073491237420220](https://jules.google.com/task/15389073491237420220) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
