### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,16 @@
+# Sentinel Journal - Security Learnings
+
+This journal records CRITICAL security learnings, vulnerability patterns, and architectural gaps found in the codebase.
+
+Format:
+## YYYY-MM-DD - [Title]
+**Vulnerability:** [What you found]
+**Learning:** [Why it existed]
+**Prevention:** [How to avoid next time]
+
+---
+
+## 2026-02-05 - Missing Reverse Tabnabbing Protection
+**Vulnerability:** Links with `target="_blank"` were not automatically getting `rel="noopener noreferrer"`, exposing users to reverse tabnabbing attacks where a malicious page could manipulate the source page.
+**Learning:** `DOMPurify` cleans attributes but does not automatically enforce `rel="noopener noreferrer"` on target blanks unless specifically configured or hooked.
+**Prevention:** Use `DOMPurify.addHook('afterSanitizeAttributes', ...)` to enforce secure attributes on external links globally.

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,12 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to target="_blank" links', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" for all target="_blank" links
+// This prevents reverse tabnabbing attacks
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel Report: [HIGH] Fix reverse tabnabbing vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Links with target="_blank" were not automatically explicitly setting rel="noopener noreferrer", potentially exposing users to reverse tabnabbing attacks where a malicious external page could manipulate the source page.
🎯 Impact: Phishing or redirection of the user's session if they click a malicious link in their notes.
🔧 Fix: Implemented a global DOMPurify hook in `src/utils/sanitize.ts` that intercepts all anchor tags and forces `rel="noopener noreferrer"` if `target="_blank"` is present.
✅ Verification: Added a new test case in `src/utils/sanitize.test.ts` verifying that sanitized HTML correctly includes the secure attribute. Ran full test suite via `npm run check`.

---
*PR created automatically by Jules for task [13487482733556794355](https://jules.google.com/task/13487482733556794355) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
