### PR TITLE
⚡ Bolt: Optimize NoteCard preview generation

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from 'react';
+import { useState, memo, useMemo } from 'react';
 import type { Note } from '../types';
 import { formatRelativeTime } from '../utils/formatTime';
 import { TagBadgeList } from './TagBadge';
@@ -12,13 +12,21 @@ interface NoteCardProps {
   isCompact?: boolean;
 }
 
+const MAX_PREVIEW_LENGTH = 1500;
+
 export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogglePin, isCompact = false }: NoteCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Optimize preview generation by truncating content first
+  const previewContent = useMemo(() => {
+    if (note.content.length <= MAX_PREVIEW_LENGTH) return note.content;
+    return note.content.slice(0, MAX_PREVIEW_LENGTH);
+  }, [note.content]);
 
   // Extract plain text preview for compact mode (no HTML escaping - React handles it)
   const compactPreview = (() => {
     if (!isCompact) return '';
-    const text = htmlToPlainText(note.content);
+    const text = htmlToPlainText(previewContent);
     return text.slice(0, 80) + (text.length > 80 ? '...' : '');
   })();
 
@@ -180,7 +188,7 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         /* Preview - Rendered HTML content (sanitized to prevent XSS) */
         <div
           className="note-card-preview flex-1 overflow-hidden"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(note.content) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(previewContent) }}
         />
       )}
 

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,14 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('handles truncated HTML gracefully', () => {
+    // Truncated inside a tag and attribute
+    const input = '<p><strong>Bold text that gets cut off here...';
+    // DOMPurify should close the tags
+    const output = sanitizeHtml(input);
+    expect(output).toBe('<p><strong>Bold text that gets cut off here...</strong></p>');
+  });
 });
 
 describe('escapeHtml', () => {


### PR DESCRIPTION
*   **💡 What:** Implemented a `MAX_PREVIEW_LENGTH` (1500 chars) for note previews in `NoteCard.tsx` and memoized the truncation logic.
*   **🎯 Why:** Large notes (e.g., 10k+ chars) were causing significant blocking time during the `sanitizeHtml` and `htmlToPlainText` operations on the dashboard, leading to frame drops when scrolling lists of large notes.
*   **📊 Impact:** Reduces sanitization complexity from O(N) to O(1) (capped constant) for preview generation.
*   **🔬 Measurement:** Verified with a Playwright script creating a 10k char note; dashboard rendered instantly with truncated content. Unit tests confirm safe handling of truncated HTML.

---
*PR created automatically by Jules for task [4551692001132101215](https://jules.google.com/task/4551692001132101215) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
