### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal - Critical Security Learnings
+
+## 2025-02-18 - Reverse Tabnabbing Vulnerability
+**Vulnerability:** External links (`target="_blank"`) without `rel="noopener noreferrer"` can allow the opened page to manipulate the original page via `window.opener`.
+**Learning:** `DOMPurify` does not automatically add `rel="noopener noreferrer"` to `target="_blank"` links unless explicitly hooked.
+**Prevention:** Added a global `DOMPurify` hook in `src/utils/sanitize.ts` to enforce `rel="noopener noreferrer"` on all `target="_blank"` links.

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,19 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" for external links
+// This prevents reverse tabnabbing attacks
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if ('tagName' in node && node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    const existingRel = node.getAttribute('rel') || '';
+    const rels = existingRel.split(' ').filter(r => r.trim());
+
+    if (!rels.includes('noopener')) rels.push('noopener');
+    if (!rels.includes('noreferrer')) rels.push('noreferrer');
+
+    node.setAttribute('rel', rels.join(' '));
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)

--- a/src/utils/sanitize_security.test.ts
+++ b/src/utils/sanitize_security.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml } from './sanitize';
+
+describe('sanitizeHtml Security', () => {
+  it('should add rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
+
+  it('should not add rel="noopener noreferrer" to links without target="_blank"', () => {
+    const input = '<a href="https://example.com">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).not.toContain('rel="noopener noreferrer"');
+  });
+
+  it('should preserve existing rel attributes while adding noopener noreferrer', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="nofollow">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('nofollow');
+    expect(output).toContain('noopener');
+    expect(output).toContain('noreferrer');
+  });
+
+  it('should not duplicate rel attributes if already present', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="noopener">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('noopener');
+    expect(output).toContain('noreferrer');
+    // Ensure noopener appears only once? DOMPurify might dedup or we might just check string.
+    // The implementation uses Set or array filtering?
+    // My implementation:
+    // if (!rels.includes('noopener')) rels.push('noopener');
+    // So it won't duplicate.
+    const relAttr = output.match(/rel="([^"]*)"/)?.[1];
+    const rels = relAttr?.split(' ') || [];
+    const noopenerCount = rels.filter(r => r === 'noopener').length;
+    expect(noopenerCount).toBe(1);
+  });
+});


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External links (`target="_blank"`) without `rel="noopener noreferrer"` can allow the opened page to manipulate the original page via `window.opener`.
🎯 Impact: A malicious page opened in a new tab could redirect the user's original tab to a phishing site.
🔧 Fix: Added a global `DOMPurify` hook in `src/utils/sanitize.ts` to automatically append `noopener noreferrer` to any `<a>` tag with `target="_blank"`. This implementation preserves existing `rel` attributes (like `nofollow`).
✅ Verification: Added unit tests in `src/utils/sanitize_security.test.ts` to verify that `rel="noopener noreferrer"` is added correctly and existing attributes are preserved.

---
*PR created automatically by Jules for task [10328238291258592367](https://jules.google.com/task/10328238291258592367) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
