### PR TITLE
Shield: Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2025-05-20 - Reverse Tabnabbing via Rich Text
+**Vulnerability:** User-generated content with `target="_blank"` links (e.g., from pasted HTML) lacked `rel="noopener noreferrer"`, exposing users to reverse tabnabbing attacks where the linked page could manipulate the origin page.
+**Learning:** `DOMPurify`'s `ADD_ATTR` option only allows attributes but does not enforce values. To enforce `rel="noopener noreferrer"`, a hook (`afterSanitizeAttributes`) is required.
+**Prevention:** Implemented a global `DOMPurify` hook in `src/utils/sanitize.ts` that automatically appends `noopener noreferrer` to any anchor tag with `target="_blank"`, while preserving existing `rel` values.

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,20 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to prevent reverse tabnabbing attacks
+// This ensures all links opening in a new tab have rel="noopener noreferrer"
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if ('target' in node && node.getAttribute('target') === '_blank') {
+    let rel = node.getAttribute('rel') || '';
+    if (!rel.includes('noopener')) {
+      rel += ' noopener';
+    }
+    if (!rel.includes('noreferrer')) {
+      rel += ' noreferrer';
+    }
+    node.setAttribute('rel', rel.trim());
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)

--- a/src/utils/sanitize_security.test.ts
+++ b/src/utils/sanitize_security.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml } from './sanitize';
+
+describe('sanitizeHtml Security', () => {
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
+
+  it('does not add rel="noopener noreferrer" to links without target="_blank"', () => {
+    const input = '<a href="https://example.com">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).not.toContain('rel="noopener noreferrer"');
+  });
+
+  it('preserves existing rel attributes while adding noopener noreferrer', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="nofollow">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="nofollow noopener noreferrer"');
+  });
+});


### PR DESCRIPTION
Implemented protection against Reverse Tabnabbing attacks by adding a DOMPurify hook that enforces `rel="noopener noreferrer"` on all links with `target="_blank"`.

Changes:
- Modified `src/utils/sanitize.ts` to add `afterSanitizeAttributes` hook.
- Created `src/utils/sanitize_security.test.ts` to verify the fix.
- Added entry to `.jules/sentinel.md` documenting the vulnerability and fix.

---
*PR created automatically by Jules for task [16973189302759592615](https://jules.google.com/task/16973189302759592615) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
