### PR TITLE
🛡️ Sentinel: [HIGH] Add noopener noreferrer to target=_blank links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+## Sentinel Security Journal
+
+## 2026-02-10 - [Reverse Tabnabbing Vulnerability]
+**Vulnerability:** Found `sanitizeHtml` allowing `target="_blank"` on `<a>` tags without enforcing `rel="noopener noreferrer"`.
+**Learning:** `DOMPurify` does not automatically enforce `noopener` or `noreferrer` for `target="_blank"` unless explicitly hooked or configured with specific options (though modern browsers do default to `noopener`). Relying on defaults is insufficient for robust security.
+**Prevention:** Always use `DOMPurify.addHook('afterSanitizeAttributes', ...)` to explicitly set `rel` attributes for `target="_blank"` links to prevent reverse tabnabbing and protect user privacy.

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" for links with target="_blank"
+// This prevents reverse tabnabbing attacks
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)

--- a/src/utils/sanitize_security.test.ts
+++ b/src/utils/sanitize_security.test.ts
@@ -1,0 +1,17 @@
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml } from './sanitize';
+
+describe('sanitizeHtml Security Check', () => {
+  it('should add rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
+
+  it('should not add rel to links without target="_blank"', () => {
+    const input = '<a href="https://example.com">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).not.toContain('rel="noopener noreferrer"');
+  });
+});


### PR DESCRIPTION
Implemented a security enhancement to prevent reverse tabnabbing attacks. Links with `target="_blank"` are now automatically sanitized to include `rel="noopener noreferrer"`. This prevents the opened page from hijacking the referring page via `window.opener`. Validated with new regression tests.

---
*PR created automatically by Jules for task [6897311594529658904](https://jules.google.com/task/6897311594529658904) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
