### PR TITLE
🛡️ Sentinel: Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,28 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    expect(output).toContain('target="_blank"');
+  });
+
+  it('preserves existing rel attributes while adding security attributes', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="nofollow">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="nofollow noopener noreferrer"');
+  });
+
+  it('does not duplicate existing security attributes', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="noopener">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    // Ensure noopener appears only once
+    const matches = output.match(/noopener/g);
+    expect(matches?.length).toBe(1);
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,25 @@
 import DOMPurify from 'dompurify';
 
+// Add global hook to force safe link attributes to prevent reverse tabnabbing
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    const rel = node.getAttribute('rel') || '';
+    const parts = rel.split(/\s+/).filter(Boolean);
+
+    // Add noopener if missing
+    if (!parts.includes('noopener')) {
+      parts.push('noopener');
+    }
+
+    // Add noreferrer if missing
+    if (!parts.includes('noreferrer')) {
+      parts.push('noreferrer');
+    }
+
+    node.setAttribute('rel', parts.join(' '));
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Links with `target="_blank"` were not automatically getting `rel="noopener noreferrer"`, allowing the opened page to potentially access `window.opener` and redirect the original page (Reverse Tabnabbing).
🎯 Impact: Users clicking on external links in notes could be phishing targets if the linked site is malicious.
🔧 Fix: Added a global `DOMPurify` hook in `src/utils/sanitize.ts` that intercepts `A` tags with `target="_blank"` and appends `noopener noreferrer` to the `rel` attribute while preserving existing values.
✅ Verification: Added unit tests in `src/utils/sanitize.test.ts` to confirm that `noopener noreferrer` is added correctly and that existing attributes are preserved. Ran full test suite with `npm run test:run` and all tests passed.

---
*PR created automatically by Jules for task [7262710385221843151](https://jules.google.com/task/7262710385221843151) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
