### PR TITLE
🛡️ Sentinel: Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,13 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    expect(output).toContain('target="_blank"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" on links with target="_blank"
+// This prevents reverse tabnabbing attacks where the new tab can access the original window
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Links with `target="_blank"` were not automatically assigned `rel="noopener noreferrer"`. This could allow a malicious site opened from a note to access the `window.opener` object and potentially redirect the user's tab to a phishing site (Reverse Tabnabbing).
🎯 Impact: If a user clicks a malicious link in a note that opens in a new tab, the malicious page could manipulate the original Yidhan tab.
🔧 Fix: Implemented a global `DOMPurify` hook in `src/utils/sanitize.ts` that intercepts all `<a>` tags with `target="_blank"` and enforces `rel="noopener noreferrer"`.
✅ Verification: Added a new test case in `src/utils/sanitize.test.ts` which confirms that the `rel` attribute is correctly added. Ran `npm run test` to verify.

---
*PR created automatically by Jules for task [7926529840419121207](https://jules.google.com/task/7926529840419121207) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
