### PR TITLE
🛡️ Sentinel: Fix Reverse Tabnabbing vulnerability

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,13 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('target="_blank"');
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,13 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce security best practices for links
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // Prevent reverse tabnabbing: any link with target="_blank" must have rel="noopener noreferrer"
+  if ('target' in node && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
This PR addresses a Reverse Tabnabbing vulnerability by ensuring all links opening in a new tab (`target="_blank"`) automatically include `rel="noopener noreferrer"`. This is achieved by adding a `DOMPurify` hook that runs during HTML sanitization.

### Changes
- Modified `src/utils/sanitize.ts` to add a `DOMPurify` hook.
- Updated `src/utils/sanitize.test.ts` to include a regression test.

### Verification
- Run `npm run test:run src/utils/sanitize.test.ts` to verify the fix.
- Full check suite `npm run check` passed.

---
*PR created automatically by Jules for task [10725096978145850309](https://jules.google.com/task/10725096978145850309) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
