### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability in sanitized HTML

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-05-22 - Missing Reverse Tabnabbing Protection
+**Vulnerability:** Links with `target="_blank"` were not automatically getting `rel="noopener noreferrer"`.
+**Learning:** `DOMPurify` does not automatically add `rel="noopener noreferrer"` to `target="_blank"` links unless explicitly configured or hooked. The `ADD_ATTR: ['target']` configuration was insufficient.
+**Prevention:** Added a global `DOMPurify.addHook('afterSanitizeAttributes', ...)` in `src/utils/sanitize.ts` to enforce this relationship. This pattern should be maintained if sanitization logic changes.

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,22 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds rel="noopener noreferrer" to target="_blank" links', () => {
+    const input = '<a href="https://example.com" target="_blank">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('target="_blank"');
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
+
+  it('preserves existing rel attributes but adds noopener noreferrer', () => {
+    const input = '<a href="https://example.com" target="_blank" rel="nofollow">Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('target="_blank"');
+    expect(output).toContain('noopener');
+    expect(output).toContain('noreferrer');
+    expect(output).toContain('nofollow');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,17 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to enforce rel="noopener noreferrer" on target="_blank" links
+// This prevents reverse tabnabbing attacks where the opened page can access the opener
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    const rel = node.getAttribute('rel') || '';
+    const parts = new Set(rel.split(' ').filter(Boolean));
+    parts.add('noopener');
+    parts.add('noreferrer');
+    node.setAttribute('rel', Array.from(parts).join(' '));
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
This PR addresses a security vulnerability where links opening in a new tab (`target="_blank"`) did not have `rel="noopener noreferrer"` attributes. This could allow the opened page to manipulate the original page (reverse tabnabbing).

I added a `DOMPurify.addHook` in `src/utils/sanitize.ts` to enforce this attribute on all sanitized HTML. I also added comprehensive tests to verify the fix and ensure existing `rel` attributes are preserved.

---
*PR created automatically by Jules for task [5182271795899400138](https://jules.google.com/task/5182271795899400138) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
