### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - Reverse Tabnabbing Vulnerability
+**Vulnerability:** Rich text sanitization allowed `target="_blank"` without `rel="noopener noreferrer"`.
+**Learning:** `DOMPurify` configuration `ADD_ATTR: ['target']` does not automatically add security attributes to external links.
+**Prevention:** Registered a global `DOMPurify` hook to enforce `rel="noopener noreferrer"` on all `target="_blank"` links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,7 +438,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Note titles:** Sanitized with DOMPurify to prevent XSS
 
 ### Sanitization Functions (`src/utils/sanitize.ts`)
-- `sanitizeHtml(html)` - Sanitize rich HTML content (allows safe tags)
+- `sanitizeHtml(html)` - Sanitize rich HTML content (allows safe tags), adds `rel="noopener noreferrer"` to external links
 - `sanitizeText(text)` - Strip HTML and escape special characters
 - `escapeHtml(text)` - Escape HTML special characters only
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Note titles:** Sanitized with DOMPurify to prevent XSS
 
 ### Sanitization Functions (`src/utils/sanitize.ts`)
-- `sanitizeHtml(html)` - Sanitize rich HTML content (allows safe tags)
+- `sanitizeHtml(html)` - Sanitize rich HTML content (allows safe tags), adds `rel="noopener noreferrer"` to external links
 - `sanitizeText(text)` - Strip HTML and escape special characters
 - `escapeHtml(text)` - Escape HTML special characters only
 

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -42,6 +42,13 @@ describe('sanitizeHtml', () => {
     const input = '<a href="https://example.com">Link</a>';
     expect(sanitizeHtml(input)).toContain('href="https://example.com"');
   });
+
+  it('adds noopener noreferrer to links with target="_blank"', () => {
+    const input = '<a href="https://example.com" target="_blank">External Link</a>';
+    const output = sanitizeHtml(input);
+    expect(output).toContain('rel="noopener noreferrer"');
+    expect(output).toContain('target="_blank"');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,5 +1,15 @@
 import DOMPurify from 'dompurify';
 
+// Add a hook to ensure all external links (target="_blank") have rel="noopener noreferrer"
+// This prevents reverse tabnabbing attacks where the new page can access the original page's window object
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if ('tagName' in node && node.tagName.toLowerCase() === 'a') {
+    if (node.getAttribute('target') === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  }
+});
+
 /**
  * Sanitize HTML content to prevent XSS attacks.
  * Allows safe HTML tags from Tiptap editor (formatting, lists, etc.)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External links (`target="_blank"`) in rich text notes lacked `rel="noopener noreferrer"`.
🎯 Impact: Malicious sites could potentially access `window.opener` to redirect the user (reverse tabnabbing) or gain information.
🔧 Fix: Registered a global `DOMPurify` hook in `src/utils/sanitize.ts` to automatically enforce `rel="noopener noreferrer"` on all `<a>` tags with `target="_blank"`.
✅ Verification: Added a test case in `src/utils/sanitize.test.ts` to verify the attribute is added.

---
*PR created automatically by Jules for task [4401641183816049066](https://jules.google.com/task/4401641183816049066) started by @anbuneel*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
