### PR TITLE
fix: UI quality sweep 2 — 404 page, demo starters, Auth refactor, polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,14 @@ See `src/data/changelog.ts` for full feature history. See `src/data/roadmap.ts` 
 3. Match the wabi-sabi aesthetic (subtle animations, warm tones)
 4. Use asymmetric border-radius: `2px 12px 4px 12px` for small elements
 
+### Styling convention
+Three approaches coexist — use the right tool for the job:
+- **Tailwind classes** (preferred default): layout, spacing, responsive breakpoints, common utilities
+- **Inline `style` props**: only for dynamic values that depend on state/props, or one-off CSS variable references not worth a class (e.g., `style={{ boxShadow: 'var(--shadow-manuscript)' }}`)
+- **CSS-in-JSX `<style>` blocks**: complex selectors, keyframes, or media queries that Tailwind can't express (e.g., LandingPage entrance animations)
+
+Avoid: creating new inline `style={{}}` objects for static values that could be a Tailwind class or a CSS class in `index.css`. Inline SVGs use `strokeWidth={1.5}` consistently.
+
 ### Modifying the editor
 - Toolbar buttons are in `EditorToolbar.tsx` with `variant` prop: `'inline'` (desktop, sticky in header zone) or `'bottom'` (mobile, fixed at thumb zone)
 - Vertical sidebar toolbar in `EditorSidebar.tsx`: curated 10-button subset (bold, italic, highlight, H1-H3, lists, quote, code block) + focus mode. Visible at ≥1100px, supplements (not replaces) the inline toolbar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ src/
 │   ├── LettingGoModal.tsx # Account departure modal with keepsakes export
 │   ├── LoadingFallback.tsx # Shared loading spinner for Suspense boundaries
 │   ├── Logo.tsx           # Shared brand component (compact mark + live wordmark for headers; header variant used consistently across all pages)
+│   ├── NotFoundPage.tsx   # 404 page for unrecognized routes
 │   ├── NoteCard.tsx       # Individual note card with tag badges
 │   ├── ShareModal.tsx     # Modal for creating/managing E2EE share links (capability-link model)
 │   ├── ShareModal.test.tsx # 18 tests: rendering, create flow, revoke, modal interactions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,14 @@ See `src/data/changelog.ts` for full feature history. See `src/data/roadmap.ts` 
 3. Match the wabi-sabi aesthetic (subtle animations, warm tones)
 4. Use asymmetric border-radius: `2px 12px 4px 12px` for small elements
 
+### Styling convention
+Three approaches coexist — use the right tool for the job:
+- **Tailwind classes** (preferred default): layout, spacing, responsive breakpoints, common utilities
+- **Inline `style` props**: only for dynamic values that depend on state/props, or one-off CSS variable references not worth a class (e.g., `style={{ boxShadow: 'var(--shadow-manuscript)' }}`)
+- **CSS-in-JSX `<style>` blocks**: complex selectors, keyframes, or media queries that Tailwind can't express (e.g., LandingPage entrance animations)
+
+Avoid: creating new inline `style={{}}` objects for static values that could be a Tailwind class or a CSS class in `index.css`. Inline SVGs use `strokeWidth={1.5}` consistently.
+
 ### Modifying the editor
 - Toolbar buttons are in `EditorToolbar.tsx` with `variant` prop: `'inline'` (desktop, sticky in header zone) or `'bottom'` (mobile, fixed at thumb zone)
 - Vertical sidebar toolbar in `EditorSidebar.tsx`: curated 10-button subset (bold, italic, highlight, H1-H3, lists, quote, code block) + focus mode. Visible at ≥1100px, supplements (not replaces) the inline toolbar.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ src/
 │   ├── LettingGoModal.tsx # Account departure modal with keepsakes export
 │   ├── LoadingFallback.tsx # Shared loading spinner for Suspense boundaries
 │   ├── Logo.tsx           # Shared brand component (compact mark + live wordmark for headers; header variant used consistently across all pages)
+│   ├── NotFoundPage.tsx   # 404 page for unrecognized routes
 │   ├── NoteCard.tsx       # Individual note card with tag badges
 │   ├── ShareModal.tsx     # Modal for creating/managing E2EE share links (capability-link model)
 │   ├── ShareModal.test.tsx # 18 tests: rendering, create flow, revoke, modal interactions

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const PlaygroundPage = import.meta.env.DEV
 const PrivacyPage = lazyWithRetry(() => import('./components/PrivacyPage').then(module => ({ default: module.PrivacyPage })));
 const TermsPage = lazyWithRetry(() => import('./components/TermsPage').then(module => ({ default: module.TermsPage })));
 const SupportPage = lazyWithRetry(() => import('./components/SupportPage').then(module => ({ default: module.SupportPage })));
+const NotFoundPage = lazyWithRetry(() => import('./components/NotFoundPage').then(module => ({ default: module.NotFoundPage })));
 
 import { TagFilterBar } from './components/TagFilterBar';
 import { WelcomeBackPrompt } from './components/WelcomeBackPrompt';
@@ -401,21 +402,34 @@ function App() {
     const match = routeableViews.find(v => path === `/${v}`);
     return match || 'library';
   });
+  // Detect unrecognized paths for 404 page
+  const [notFound, setNotFound] = useState<boolean>(() => {
+    const path = window.location.pathname.replace(/\/$/, '') || '/';
+    if (path === '/') return false;
+    if (routeableViews.some(v => path === `/${v}`)) return false;
+    if (path === '/demo') return false;
+    if (path.startsWith('/s/')) return false;
+    if (import.meta.env.DEV && path === '/playground') return false;
+    return true;
+  });
   // Sync URL pathname for direct-entry routes
   useEffect(() => {
     // Don't overwrite /demo path; /playground is dev-only and gated separately
     const currentPath = window.location.pathname;
     if (currentPath === '/demo' || (import.meta.env.DEV && currentPath === '/playground')) return;
+    // Don't overwrite 404 path — keep the bad URL visible for debugging
+    if (notFound) return;
     const expectedPath = routeableViews.includes(view) ? `/${view}` : '/';
     if (currentPath !== expectedPath) {
       window.history.pushState({}, '', expectedPath);
     }
-  }, [view]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [view, notFound]); // eslint-disable-line react-hooks/exhaustive-deps
   // Handle browser back/forward navigation
   useEffect(() => {
     const handlePopState = () => {
       const path = window.location.pathname.replace(/\/$/, '') || '/';
       const match = routeableViews.find(v => path === `/${v}`);
+      setNotFound(false);
       setView(match || 'library');
     };
     window.addEventListener('popstate', handlePopState);
@@ -1961,6 +1975,23 @@ function App() {
             }}
             onChangelogClick={() => startTransition(() => setView('changelog'))}
             onRoadmapClick={() => startTransition(() => setView('roadmap'))}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    );
+  }
+
+  // 404 page for unrecognized routes
+  if (notFound) {
+    return (
+      <ErrorBoundary>
+        <Suspense fallback={<LoadingFallback />}>
+          <NotFoundPage
+            onGoHome={() => {
+              setNotFound(false);
+              setView('library');
+              window.history.replaceState({}, '', '/');
+            }}
           />
         </Suspense>
       </ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -428,8 +428,22 @@ function App() {
   useEffect(() => {
     const handlePopState = () => {
       const path = window.location.pathname.replace(/\/$/, '') || '/';
-      const match = routeableViews.find(v => path === `/${v}`);
+
+      // Recompute 404 state for the new URL (mirrors the useState initializer)
+      const isKnownRoute =
+        path === '/' ||
+        routeableViews.some(v => path === `/${v}`) ||
+        path === '/demo' ||
+        path.startsWith('/s/') ||
+        (import.meta.env.DEV && path === '/playground');
+
+      if (!isKnownRoute) {
+        setNotFound(true);
+        return;
+      }
+
       setNotFound(false);
+      const match = routeableViews.find(v => path === `/${v}`);
       setView(match || 'library');
     };
     window.addEventListener('popstate', handlePopState);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -63,22 +63,6 @@ interface AuthProps {
   onClose?: () => void;
 }
 
-// Shared input field styles and handlers to reduce repetition
-const inputBaseStyles: React.CSSProperties = {
-  fontFamily: 'var(--font-body)',
-  background: 'var(--color-bg-secondary)',
-  border: '1px solid var(--glass-border)',
-  color: 'var(--color-text-primary)',
-};
-
-const inputFocusHandler = (e: React.FocusEvent<HTMLInputElement>) => {
-  e.currentTarget.style.borderColor = 'var(--color-accent)';
-};
-
-const inputBlurHandler = (e: React.FocusEvent<HTMLInputElement>) => {
-  e.currentTarget.style.borderColor = 'var(--glass-border)';
-};
-
 // Reusable OAuth button component
 interface OAuthButtonProps {
   provider: 'google' | 'github';
@@ -114,21 +98,7 @@ function OAuthButton({ provider, onClick, loading, disabled }: OAuthButtonProps)
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex-1 py-3 rounded-lg font-medium transition-all duration-200 disabled:opacity-50 flex items-center justify-center gap-2"
-      style={{
-        fontFamily: 'var(--font-body)',
-        background: 'var(--color-bg-secondary)',
-        border: '1px solid var(--glass-border)',
-        color: 'var(--color-text-primary)',
-      }}
-      onMouseEnter={(e) => {
-        if (!disabled) {
-          e.currentTarget.style.borderColor = 'var(--color-accent)';
-        }
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.borderColor = 'var(--glass-border)';
-      }}
+      className="auth-btn-secondary flex-1 py-3 rounded-lg font-medium transition-all duration-200 disabled:opacity-50 flex items-center justify-center gap-2"
     >
       {loading ? 'Redirecting...' : (
         <>
@@ -332,12 +302,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
   // Auth card content (shared between modal and full page)
   const authCard = (
     <div
-        className="w-full max-w-[440px] p-6 md:p-10 mx-auto"
-        style={{
-          background: 'var(--color-card-bg)',
-          border: '1px solid var(--glass-border)',
-          borderRadius: 'var(--radius-card)',
-        }}
+        className="auth-card w-full max-w-[440px] p-6 md:p-10 mx-auto"
       >
         {/* Logo/Title */}
         <h1 className="mb-2 flex justify-center">
@@ -345,10 +310,8 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
         </h1>
         <h2
           id="auth-modal-title"
-          className={`text-center ${!awaitingConfirmation && (mode === 'signup' || mode === 'login') ? 'mb-2' : 'mb-6 md:mb-10'}`}
+          className={`auth-text-secondary text-center ${!awaitingConfirmation && (mode === 'signup' || mode === 'login') ? 'mb-2' : 'mb-6 md:mb-10'}`}
           style={{
-            fontFamily: 'var(--font-body)',
-            color: 'var(--color-text-secondary)',
             fontSize: '0.95rem',
             fontWeight: 'normal',
           }}
@@ -358,12 +321,8 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
         {/* Top reassurance — calm, intimate (P1 #9) */}
         {!awaitingConfirmation && (mode === 'signup' || mode === 'login') && (
           <p
-            className="text-center mb-6 md:mb-10"
-            style={{
-              fontFamily: 'var(--font-body)',
-              color: 'var(--color-text-tertiary)',
-              fontSize: '0.8rem',
-            }}
+            className="auth-text-tertiary text-center mb-6 md:mb-10"
+            style={{ fontSize: '0.8rem' }}
           >
             Your private writing space
           </p>
@@ -374,15 +333,13 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           <div className="text-center">
             {/* Email icon */}
             <div
-              className="mx-auto mb-6 w-16 h-16 rounded-full flex items-center justify-center"
-              style={{ background: 'var(--color-bg-secondary)' }}
+              className="mx-auto mb-6 w-16 h-16 rounded-full flex items-center justify-center bg-[var(--color-bg-secondary)]"
             >
               <svg
-                className="w-8 h-8"
+                className="w-8 h-8 text-[var(--color-accent)]"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
-                style={{ color: 'var(--color-accent)' }}
               >
                 <path
                   strokeLinecap="round"
@@ -394,20 +351,12 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             </div>
 
             <p
-              className="mb-2"
-              style={{
-                fontFamily: 'var(--font-body)',
-                color: 'var(--color-text-primary)',
-              }}
+              className="auth-text mb-2 text-[var(--color-text-primary)]"
             >
               We sent a confirmation link to
             </p>
             <p
-              className="mb-6 font-medium"
-              style={{
-                fontFamily: 'var(--font-body)',
-                color: 'var(--color-accent)',
-              }}
+              className="auth-text-accent auth-text mb-6 font-medium"
             >
               {email}
             </p>
@@ -415,16 +364,14 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             {/* Success/Error Messages */}
             {error && (
               <p
-                className="mb-4 text-sm"
-                style={{ color: 'var(--color-destructive)' }}
+                className="auth-text-destructive mb-4 text-sm"
               >
                 {error}
               </p>
             )}
             {message && (
               <p
-                className="mb-4 text-sm"
-                style={{ color: 'var(--color-accent)' }}
+                className="auth-text-accent mb-4 text-sm"
               >
                 {message}
               </p>
@@ -432,11 +379,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
 
             {/* Helpful tip */}
             <p
-              className="mb-6 text-sm"
-              style={{
-                fontFamily: 'var(--font-body)',
-                color: 'var(--color-text-tertiary)',
-              }}
+              className="auth-text-tertiary mb-6 text-sm"
             >
               Check your spam folder if you don't see it
             </p>
@@ -447,20 +390,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
                 type="button"
                 onClick={handleResendConfirmation}
                 disabled={loading || resendCooldown > 0}
-                className="w-full py-3 rounded-lg font-medium transition-all duration-200 disabled:opacity-50"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  background: 'var(--color-cta-bg)',
-                  color: 'var(--color-cta-text)',
-                }}
-                onMouseEnter={(e) => {
-                  if (!loading && resendCooldown === 0) {
-                    e.currentTarget.style.background = 'var(--color-cta-bg-hover)';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--color-cta-bg)';
-                }}
+                className="auth-btn-cta w-full py-3 rounded-lg font-medium transition-all duration-200 disabled:opacity-50"
               >
                 {loading && 'Sending...'}
                 {!loading && resendCooldown > 0 && `Resend in ${resendCooldown}s`}
@@ -469,19 +399,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
               <button
                 type="button"
                 onClick={handleChangeEmail}
-                className="w-full py-3 rounded-lg font-medium transition-all duration-200"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  background: 'var(--color-bg-secondary)',
-                  border: '1px solid var(--glass-border)',
-                  color: 'var(--color-text-primary)',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.borderColor = 'var(--color-accent)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.borderColor = 'var(--glass-border)';
-                }}
+                className="auth-btn-secondary w-full py-3 rounded-lg font-medium transition-all duration-200"
               >
                 Use a different email
               </button>
@@ -510,21 +428,15 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             {/* Divider */}
             <div className="flex items-center mb-4 md:mb-6">
               <div
-                className="flex-1 h-px"
-                style={{ background: 'var(--glass-border)' }}
+                className="auth-divider-line flex-1 h-px"
               />
               <span
-                className="px-4 text-sm"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary px-4 text-sm"
               >
                 or continue with email
               </span>
               <div
-                className="flex-1 h-px"
-                style={{ background: 'var(--glass-border)' }}
+                className="auth-divider-line flex-1 h-px"
               />
             </div>
           </>
@@ -536,11 +448,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             <div className="mb-4 md:mb-5">
               <label
                 htmlFor="auth-email"
-                className="block text-sm mb-2"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary block text-sm mb-2"
               >
                 Email
               </label>
@@ -551,10 +459,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
-                style={inputBaseStyles}
-                onFocus={inputFocusHandler}
-                onBlur={inputBlurHandler}
+                className="auth-input w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
               />
             </div>
           )}
@@ -564,11 +469,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             <div className="mb-4 md:mb-5">
               <label
                 htmlFor="auth-password"
-                className="block text-sm mb-2"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary block text-sm mb-2"
               >
                 {mode === 'reset' ? 'New Password' : 'Password'}
               </label>
@@ -580,18 +481,11 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={8}
-                className="w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
-                style={inputBaseStyles}
-                onFocus={inputFocusHandler}
-                onBlur={inputBlurHandler}
+                className="auth-input w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
               />
               {(mode === 'signup' || mode === 'reset') && (
                 <p
-                  className="text-xs mt-1.5"
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    color: 'var(--color-text-tertiary)',
-                  }}
+                  className="auth-text-tertiary text-xs mt-1.5"
                 >
                   8+ characters
                 </p>
@@ -604,11 +498,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             <div className="mb-4 md:mb-5">
               <label
                 htmlFor="auth-confirm-password"
-                className="block text-sm mb-2"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary block text-sm mb-2"
               >
                 Confirm Password
               </label>
@@ -620,10 +510,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
                 minLength={8}
-                className="w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
-                style={inputBaseStyles}
-                onFocus={inputFocusHandler}
-                onBlur={inputBlurHandler}
+                className="auth-input w-full px-4 py-3 rounded-lg outline-none transition-all duration-200"
               />
             </div>
           )}
@@ -633,11 +520,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             <div className="mb-4 md:mb-6 flex items-center justify-between">
               {/* Keep me signed in checkbox */}
               <label
-                className="flex items-center gap-2 cursor-pointer select-none"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary flex items-center gap-2 cursor-pointer select-none"
               >
                 <input
                   type="checkbox"
@@ -652,17 +535,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
               <button
                 type="button"
                 onClick={() => switchMode('forgot')}
-                className="text-sm transition-colors"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.color = 'var(--color-accent)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.color = 'var(--color-text-secondary)';
-                }}
+                className="auth-link text-sm transition-colors"
               >
                 Forgot password?
               </button>
@@ -672,8 +545,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           {/* Error Message */}
           {error && (
             <p
-              className="mb-4 text-sm text-center"
-              style={{ color: 'var(--color-destructive)' }}
+              className="auth-text-destructive mb-4 text-sm text-center"
             >
               {error}
             </p>
@@ -682,8 +554,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           {/* Success Message */}
           {message && (
             <p
-              className="mb-4 text-sm text-center"
-              style={{ color: 'var(--color-accent)' }}
+              className="auth-text-accent mb-4 text-sm text-center"
             >
               {message}
             </p>
@@ -694,6 +565,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             type="submit"
             disabled={loading}
             className="
+              auth-btn-cta
               w-full py-3
               rounded-lg
               font-medium
@@ -701,18 +573,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
               disabled:opacity-50
             "
             style={{
-              fontFamily: 'var(--font-body)',
-              background: 'var(--color-cta-bg)',
-              color: 'var(--color-cta-text)',
               boxShadow: '0 4px 20px var(--color-accent-glow)',
-            }}
-            onMouseEnter={(e) => {
-              if (!loading) {
-                e.currentTarget.style.background = 'var(--color-cta-bg-hover)';
-              }
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = 'var(--color-cta-bg)';
             }}
           >
             {loading ? (
@@ -746,15 +607,14 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
         </form>
 
         {/* Footer Links */}
-        <div className="text-center mt-4 md:mt-6 text-sm" style={{ fontFamily: 'var(--font-body)' }}>
+        <div className="auth-text text-center mt-4 md:mt-6 text-sm">
           {mode === 'login' && (
-            <p style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="auth-text-secondary">
               Don't have an account?{' '}
               <button
                 type="button"
                 onClick={() => switchMode('signup')}
-                className="underline transition-colors"
-                style={{ color: 'var(--color-accent)' }}
+                className="auth-text-accent underline transition-colors"
               >
                 Sign Up
               </button>
@@ -762,13 +622,12 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           )}
 
           {mode === 'signup' && (
-            <p style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="auth-text-secondary">
               Already have an account?{' '}
               <button
                 type="button"
                 onClick={() => switchMode('login')}
-                className="underline transition-colors"
-                style={{ color: 'var(--color-accent)' }}
+                className="auth-text-accent underline transition-colors"
               >
                 Sign In
               </button>
@@ -776,13 +635,12 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           )}
 
           {mode === 'forgot' && (
-            <p style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="auth-text-secondary">
               Remember your password?{' '}
               <button
                 type="button"
                 onClick={() => switchMode('login')}
-                className="underline transition-colors"
-                style={{ color: 'var(--color-accent)' }}
+                className="auth-text-accent underline transition-colors"
               >
                 Sign In
               </button>
@@ -790,12 +648,11 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           )}
 
           {mode === 'reset' && (
-            <p style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="auth-text-secondary">
               <button
                 type="button"
                 onClick={() => switchMode('login')}
-                className="underline transition-colors"
-                style={{ color: 'var(--color-accent)' }}
+                className="auth-text-accent underline transition-colors"
               >
                 Back to Sign In
               </button>
@@ -805,12 +662,8 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
 
         {/* E2EE Trust Signal */}
         <p
-          className="text-center mt-6 text-xs"
-          style={{
-            fontFamily: 'var(--font-body)',
-            color: 'var(--color-text-tertiary)',
-            letterSpacing: '0.03em',
-          }}
+          className="auth-text-tertiary text-center mt-6 text-xs"
+          style={{ letterSpacing: '0.03em' }}
         >
           Your notes stay encrypted and yours.
         </p>
@@ -884,35 +737,21 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
                 Discard changes?
               </h3>
               <p
-                className="text-sm mb-6"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="auth-text-secondary text-sm mb-6"
               >
                 You have unsaved changes that will be lost.
               </p>
               <div className="flex justify-center gap-3">
                 <button
                   onClick={() => setShowCloseConfirm(false)}
-                  className="px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    color: 'var(--color-text-secondary)',
-                    background: 'transparent',
-                    border: '1px solid var(--glass-border)',
-                  }}
+                  className="auth-btn-secondary px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
+                  style={{ background: 'transparent' }}
                 >
                   Keep Editing
                 </button>
                 <button
                   onClick={handleConfirmClose}
-                  className="px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    color: 'var(--color-cta-text)',
-                    background: 'var(--color-cta-bg)',
-                  }}
+                  className="auth-btn-cta px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
                 >
                   Discard
                 </button>
@@ -927,8 +766,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
   // Full page mode: wrap in page container with theme toggle
   return (
     <div
-      className="min-h-screen flex items-center justify-center px-4 relative"
-      style={{ background: 'var(--color-bg-primary)' }}
+      className="min-h-screen flex items-center justify-center px-4 relative bg-[var(--color-bg-primary)]"
     >
       {/* Theme Toggle */}
       <button
@@ -943,12 +781,10 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
           focus:outline-none
           focus:ring-2
           focus:ring-[var(--color-accent)]
+          text-[var(--color-text-secondary)]
           hover:text-[var(--color-accent)]
           hover:-translate-y-0.5
         "
-        style={{
-          color: 'var(--color-text-secondary)',
-        }}
         aria-label="Toggle theme"
       >
         {theme === 'light' ? (

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -744,8 +744,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
               <div className="flex justify-center gap-3">
                 <button
                   onClick={() => setShowCloseConfirm(false)}
-                  className="auth-btn-secondary px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
-                  style={{ background: 'transparent' }}
+                  className="auth-btn-ghost px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200"
                 >
                   Keep Editing
                 </button>

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -853,7 +853,7 @@ export function Auth({ theme, onThemeToggle, initialMode = 'login', onPasswordRe
             aria-label="Close"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
           {authCard}

--- a/src/components/ChapterSection.tsx
+++ b/src/components/ChapterSection.tsx
@@ -209,7 +209,7 @@ export const ChapterSection = memo(function ChapterSection({
               viewBox="0 0 24 24"
               style={{ color: 'var(--color-text-tertiary)' }}
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
             </svg>
           )}
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1152,7 +1152,7 @@ export function Editor({ note, tags, userId, onBack, onRequestSearch, onUpdate, 
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                strokeWidth={2}
+                strokeWidth={1.5}
                 d="M19 14l-7 7m0 0l-7-7m7 7V3"
               />
             </svg>
@@ -1186,7 +1186,7 @@ export function Editor({ note, tags, userId, onBack, onRequestSearch, onUpdate, 
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  strokeWidth={2}
+                  strokeWidth={1.5}
                   d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
                 />
               </svg>

--- a/src/components/EditorSidebar.tsx
+++ b/src/components/EditorSidebar.tsx
@@ -55,7 +55,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('italic')}
           title="Italic (Ctrl+I)"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M10 4h4m2 0l-6 16m-2 0h4" />
           </svg>
         </SidebarButton>
@@ -64,7 +64,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('highlight')}
           title="Highlight"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
           </svg>
         </SidebarButton>
@@ -102,7 +102,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('bulletList')}
           title="Bullet List"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h.01M8 6h12M4 12h.01M8 12h12M4 18h.01M8 18h12" />
           </svg>
         </SidebarButton>
@@ -111,7 +111,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('taskList')}
           title="Task List"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
           </svg>
         </SidebarButton>
@@ -124,7 +124,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('blockquote')}
           title="Quote"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4z" />
           </svg>
         </SidebarButton>
@@ -133,7 +133,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
           isActive={editor.isActive('codeBlock')}
           title="Code Block"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
           </svg>
         </SidebarButton>
@@ -146,7 +146,7 @@ export function EditorSidebar({ editor, onToggleFocusMode }: EditorSidebarProps)
             onClick={onToggleFocusMode}
             title="Focus mode (Ctrl+Shift+F)"
           >
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
             </svg>
           </SidebarButton>

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -189,7 +189,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('italic')}
       title="Italic (Ctrl+I)"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M10 4h4m2 0l-6 16m-2 0h4" />
       </svg>
     </ToolbarButton>
@@ -201,7 +201,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('underline')}
       title="Underline (Ctrl+U)"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M7 4v7a5 5 0 0010 0V4M5 20h14" />
       </svg>
     </ToolbarButton>
@@ -213,7 +213,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('strike')}
       title="Strikethrough"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M16 4H9a3 3 0 00-3 3v0a3 3 0 003 3h6a3 3 0 013 3v0a3 3 0 01-3 3H7M4 12h16" />
       </svg>
     </ToolbarButton>
@@ -225,7 +225,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('highlight')}
       title="Highlight"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
       </svg>
     </ToolbarButton>
@@ -267,7 +267,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('bulletList')}
       title="Bullet List"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h.01M8 6h12M4 12h.01M8 12h12M4 18h.01M8 18h12" />
       </svg>
     </ToolbarButton>
@@ -279,7 +279,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('orderedList')}
       title="Numbered List"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h.01M4 12h.01M4 18h.01M8 6h12M8 12h12M8 18h12" />
         <text x="2" y="7" fontSize="6" fill="currentColor">1</text>
         <text x="2" y="13" fontSize="6" fill="currentColor">2</text>
@@ -294,7 +294,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('taskList')}
       title="Task List"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
       </svg>
     </ToolbarButton>
@@ -306,7 +306,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('blockquote')}
       title="Quote"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4z" />
       </svg>
     </ToolbarButton>
@@ -318,7 +318,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       isActive={editor.isActive('codeBlock')}
       title="Code Block"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
       </svg>
     </ToolbarButton>
@@ -329,7 +329,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       onClick={() => editor.chain().focus().setHorizontalRule().run()}
       title="Horizontal Rule"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M4 12h16" />
       </svg>
     </ToolbarButton>
@@ -341,7 +341,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       disabled={!editor.can().undo()}
       title="Undo (Ctrl+Z)"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a5 5 0 015 5v2M3 10l4-4m-4 4l4 4" />
       </svg>
     </ToolbarButton>
@@ -353,7 +353,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
       disabled={!editor.can().redo()}
       title="Redo (Ctrl+Shift+Z)"
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" d="M21 10H11a5 5 0 00-5 5v2m15-7l-4-4m4 4l-4 4" />
       </svg>
     </ToolbarButton>
@@ -366,7 +366,7 @@ export function EditorToolbar({ editor, variant = 'inline', onToggleFocusMode }:
         onClick={onToggleFocusMode}
         title="Focus mode (Ctrl+Shift+F)"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
         </svg>
       </ToolbarButton>

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -52,7 +52,7 @@ describe('Header', () => {
     rerender(<Header {...defaultProps} searchFocusToken={101} />);
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search...')).toHaveFocus();
+      expect(screen.getByPlaceholderText('Search your thoughts...')).toHaveFocus();
     });
   });
 
@@ -77,13 +77,13 @@ describe('Header', () => {
     await user.click(screen.getByRole('button', { name: 'Request focus' }));
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search...')).toHaveFocus();
+      expect(screen.getByPlaceholderText('Search your thoughts...')).toHaveFocus();
     });
 
     await user.click(screen.getByRole('button', { name: 'Toggle header' }));
     await user.click(screen.getByRole('button', { name: 'Toggle header' }));
 
-    expect(screen.getByPlaceholderText('Search...')).not.toHaveFocus();
+    expect(screen.getByPlaceholderText('Search your thoughts...')).not.toHaveFocus();
   });
 
   it('clears and blurs search on Escape', async () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -182,7 +182,7 @@ export function Header({
               }}
             >
               <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           ) : (
@@ -243,7 +243,7 @@ export function Header({
       aria-label="New note"
     >
       <svg className="w-5 h-5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
       </svg>
       <span className="hidden sm:inline text-sm font-medium">New Note</span>
     </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -165,7 +165,7 @@ export function Header({
             }}
             onFocus={() => setIsSearchFocused(true)}
             onBlur={() => setIsSearchFocused(false)}
-            placeholder="Search..."
+            placeholder="Search your thoughts..."
             className="flex-1 bg-transparent border-none outline-none text-sm min-w-0"
             style={{
               fontFamily: 'var(--font-body)',

--- a/src/components/IOSInstallGuide.tsx
+++ b/src/components/IOSInstallGuide.tsx
@@ -152,7 +152,7 @@ export function IOSInstallGuide({ onDismiss }: IOSInstallGuideProps) {
             aria-label="Close guide"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -158,7 +158,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
               aria-label="Close"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -283,7 +283,7 @@ export function LandingPage({
         .landing-cta-cluster {
           display: flex;
           flex-direction: column;
-          gap: 0.6rem;
+          gap: 1rem;
         }
 
         .landing-cta-button {

--- a/src/components/LettingGoModal.tsx
+++ b/src/components/LettingGoModal.tsx
@@ -219,7 +219,7 @@ export function LettingGoModal({ isOpen, onClose, notes, tags }: LettingGoModalP
               }}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -1,0 +1,52 @@
+import { Logo } from './Logo';
+
+interface NotFoundPageProps {
+  onGoHome: () => void;
+}
+
+export function NotFoundPage({ onGoHome }: NotFoundPageProps) {
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-6"
+      style={{ background: 'var(--color-bg-primary)' }}
+    >
+      <Logo variant="header" className="mb-12 opacity-40" />
+      <h1
+        className="text-3xl md:text-4xl mb-4"
+        style={{
+          fontFamily: 'var(--font-display)',
+          color: 'var(--color-text-primary)',
+          fontWeight: 300,
+        }}
+      >
+        This path leads nowhere.
+      </h1>
+      <p
+        className="mb-8"
+        style={{
+          fontFamily: 'var(--font-body)',
+          color: 'var(--color-text-secondary)',
+          fontSize: '1.1rem',
+        }}
+      >
+        Your notes are waiting.
+      </p>
+      <button
+        onClick={onGoHome}
+        className="focus-ring"
+        style={{
+          fontFamily: 'var(--font-body)',
+          color: 'var(--color-accent)',
+          background: 'none',
+          border: 'none',
+          fontSize: '1rem',
+          cursor: 'pointer',
+          textDecoration: 'underline',
+          textUnderlineOffset: '4px',
+        }}
+      >
+        Return home
+      </button>
+    </div>
+  );
+}

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -22,27 +22,20 @@ export function NotFoundPage({ onGoHome }: NotFoundPageProps) {
         This path leads nowhere.
       </h1>
       <p
-        className="mb-8"
+        className="mb-8 text-lg"
         style={{
           fontFamily: 'var(--font-body)',
           color: 'var(--color-text-secondary)',
-          fontSize: '1.1rem',
         }}
       >
         Your notes are waiting.
       </p>
       <button
         onClick={onGoHome}
-        className="focus-ring"
+        className="focus-ring bg-transparent border-none text-base cursor-pointer underline underline-offset-4"
         style={{
           fontFamily: 'var(--font-body)',
           color: 'var(--color-accent)',
-          background: 'none',
-          border: 'none',
-          fontSize: '1rem',
-          cursor: 'pointer',
-          textDecoration: 'underline',
-          textUnderlineOffset: '4px',
         }}
       >
         Return home

--- a/src/components/PullToRefresh.tsx
+++ b/src/components/PullToRefresh.tsx
@@ -231,7 +231,7 @@ export function PullToRefresh({
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
-              strokeWidth={2}
+              strokeWidth={1.5}
               d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
             />
           </svg>

--- a/src/components/ReAuthModal.tsx
+++ b/src/components/ReAuthModal.tsx
@@ -151,7 +151,7 @@ export function ReAuthModal({
               aria-label="Cancel"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>

--- a/src/components/SessionTimeoutModal.tsx
+++ b/src/components/SessionTimeoutModal.tsx
@@ -77,7 +77,7 @@ export function SessionTimeoutModal({
               aria-label="Stay signed in"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>

--- a/src/components/ShareModal.test.tsx
+++ b/src/components/ShareModal.test.tsx
@@ -313,8 +313,9 @@ describe('ShareModal', () => {
 
       const { container } = render(<ShareModal {...defaultProps} onClose={onClose} />);
 
+      // Wait for loading to finish — backdrop onClick is disabled while isProcessing
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: 'Share as Letter' })).toBeInTheDocument();
+        expect(screen.getByText('Link expires in')).toBeInTheDocument();
       });
 
       // Click the backdrop (the outermost fixed div) using fireEvent to bypass coordinate issues

--- a/src/components/SlashCommand.tsx
+++ b/src/components/SlashCommand.tsx
@@ -34,68 +34,68 @@ function formatDateTime(): string {
 // Slash command icons
 const icons = {
   heading1: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h8" />
     </svg>
   ),
   heading2: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10" />
     </svg>
   ),
   heading3: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h6" />
     </svg>
   ),
   bulletList: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h.01M8 6h12M4 12h.01M8 12h12M4 18h.01M8 18h12" />
     </svg>
   ),
   numberedList: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h.01M8 6h12M4 12h.01M8 12h12M4 18h.01M8 18h12" />
       <text x="2" y="7" fontSize="5" fill="currentColor" stroke="none">1</text>
     </svg>
   ),
   todoList: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
     </svg>
   ),
   quote: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4z" />
     </svg>
   ),
   code: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
     </svg>
   ),
   highlight: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
     </svg>
   ),
   divider: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 12h16" />
     </svg>
   ),
   date: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
     </svg>
   ),
   time: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),
   now: (
-    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),

--- a/src/components/SwipeableNoteCard.tsx
+++ b/src/components/SwipeableNoteCard.tsx
@@ -167,7 +167,7 @@ export const SwipeableNoteCard = memo(function SwipeableNoteCard({
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
-              strokeWidth={2}
+              strokeWidth={1.5}
               d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
             />
           </svg>

--- a/src/components/SyncIndicator.tsx
+++ b/src/components/SyncIndicator.tsx
@@ -129,7 +129,7 @@ export function SyncIndicator({
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
-            strokeWidth={2}
+            strokeWidth={1.5}
             d="M18.5 5.5l-3 3m0-3l3 3"
           />
         </svg>

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -173,7 +173,7 @@ export function TagFilterBar({
           >
             +{hiddenCount}
             <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
             </svg>
           </button>
         )}
@@ -200,7 +200,7 @@ export function TagFilterBar({
             aria-label="Collapse tags"
           >
             <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 15l7-7 7 7" />
             </svg>
           </button>
         )}

--- a/src/components/TagPill.tsx
+++ b/src/components/TagPill.tsx
@@ -87,7 +87,7 @@ export function TagPill({ tag, isActive = false, onClick, onEdit, showRemove, on
           aria-label="Edit tag"
         >
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
           </svg>
         </button>
       )}
@@ -115,7 +115,7 @@ export function TagPill({ tag, isActive = false, onClick, onEdit, showRemove, on
           aria-label="Remove tag"
         >
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
       )}
@@ -198,7 +198,7 @@ export function AddTagPill({ onClick }: AddTagPillProps) {
       aria-label="Add new tag"
     >
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
       </svg>
     </button>
   );

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -97,7 +97,7 @@ export function TagSelector({
                   >
                     {isSelected && (
                       <svg className="w-3 h-3" fill="none" stroke={colorValue} viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
                       </svg>
                     )}
                   </span>
@@ -140,7 +140,7 @@ export function TagSelector({
                 }}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
                 </svg>
                 Create new tag
               </button>
@@ -188,7 +188,7 @@ export function TagSelector({
           }}
         >
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
           </svg>
           {selectedTags.length === 0 && <span>Add tag</span>}
         </button>

--- a/src/components/WhisperBack.tsx
+++ b/src/components/WhisperBack.tsx
@@ -103,7 +103,7 @@ export function WhisperBack({ scrollContainerRef }: WhisperBackProps) {
         <path
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth={2}
+          strokeWidth={1.5}
           d="M5 15l7-7 7 7"
         />
       </svg>

--- a/src/components/demo/ImpermanenceRibbon.tsx
+++ b/src/components/demo/ImpermanenceRibbon.tsx
@@ -126,7 +126,7 @@ export function ImpermanenceRibbon({ onSignUp, onDismiss }: ImpermanenceRibbonPr
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
-              strokeWidth={2}
+              strokeWidth={1.5}
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1123,6 +1123,83 @@ body::before {
   color: var(--color-text-primary);
 }
 
+/* Auth component utilities */
+.auth-text {
+  font-family: var(--font-body);
+}
+
+.auth-text-secondary {
+  font-family: var(--font-body);
+  color: var(--color-text-secondary);
+}
+
+.auth-text-tertiary {
+  font-family: var(--font-body);
+  color: var(--color-text-tertiary);
+}
+
+.auth-text-accent {
+  color: var(--color-accent);
+}
+
+.auth-text-destructive {
+  color: var(--color-destructive);
+}
+
+.auth-btn-cta {
+  font-family: var(--font-body);
+  background: var(--color-cta-bg);
+  color: var(--color-cta-text);
+  cursor: pointer;
+  border: none;
+}
+
+.auth-btn-cta:hover:not(:disabled) {
+  background: var(--color-cta-bg-hover);
+}
+
+.auth-btn-secondary {
+  font-family: var(--font-body);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--glass-border);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.auth-btn-secondary:hover:not(:disabled) {
+  border-color: var(--color-accent);
+}
+
+.auth-input {
+  font-family: var(--font-body);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--glass-border);
+  color: var(--color-text-primary);
+}
+
+.auth-input:focus {
+  border-color: var(--color-accent);
+}
+
+.auth-divider-line {
+  background: var(--glass-border);
+}
+
+.auth-link {
+  font-family: var(--font-body);
+  color: var(--color-text-secondary);
+}
+
+.auth-link:hover {
+  color: var(--color-accent);
+}
+
+.auth-card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-card);
+}
+
 /* Masonry Grid Layout */
 .masonry-grid {
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -1124,6 +1124,7 @@ body::before {
 }
 
 /* Auth component utilities */
+/* Explicit body font for elements that may inherit display font */
 .auth-text {
   font-family: var(--font-body);
 }
@@ -1167,6 +1168,18 @@ body::before {
 }
 
 .auth-btn-secondary:hover:not(:disabled) {
+  border-color: var(--color-accent);
+}
+
+.auth-btn-ghost {
+  font-family: var(--font-body);
+  background: transparent;
+  border: 1px solid var(--glass-border);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.auth-btn-ghost:hover:not(:disabled) {
   border-color: var(--color-accent);
 }
 

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -638,7 +638,7 @@ function DemoHeader({
                   aria-label="Clear search"
                 >
                   <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
               ) : (
@@ -697,7 +697,7 @@ function DemoHeader({
           aria-label="New note"
         >
           <svg className="w-5 h-5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
           </svg>
           <span className="hidden sm:inline text-sm font-medium">New Note</span>
         </button>

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -619,7 +619,7 @@ function DemoHeader({
                 }}
                 onFocus={() => setIsSearchFocused(true)}
                 onBlur={() => setIsSearchFocused(false)}
-                placeholder="Search..."
+                placeholder="Search your thoughts..."
                 aria-label="Search notes"
                 className="flex-1 bg-transparent border-none outline-none text-sm min-w-0"
                 style={{

--- a/src/services/demoStorage.ts
+++ b/src/services/demoStorage.ts
@@ -416,11 +416,15 @@ export function getDemoDataForMigration(): {
   tags: DemoTag[];
 } {
   const state = getDemoState();
+  const userHasState = hasDemoState();
   return {
-    // Include starter notes only if they have been edited, exclude if unchanged
-    notes: state.notes.filter(
-      (n) => !STARTER_NOTE_IDS.has(n.localId) || hasStarterNoteBeenEdited(n)
-    ),
+    // First visit (no user-created notes, no edits): include all notes
+    // Once the user has created or edited something: exclude unedited starters
+    notes: userHasState
+      ? state.notes.filter(
+          (n) => !STARTER_NOTE_IDS.has(n.localId) || hasStarterNoteBeenEdited(n)
+        )
+      : state.notes,
     tags: state.tags,
   };
 }

--- a/src/services/demoStorage.ts
+++ b/src/services/demoStorage.ts
@@ -416,15 +416,12 @@ export function getDemoDataForMigration(): {
   tags: DemoTag[];
 } {
   const state = getDemoState();
-  const userHasState = hasDemoState();
   return {
-    // First visit (no user-created notes, no edits): include all notes
-    // Once the user has created or edited something: exclude unedited starters
-    notes: userHasState
-      ? state.notes.filter(
-          (n) => !STARTER_NOTE_IDS.has(n.localId) || hasStarterNoteBeenEdited(n)
-        )
-      : state.notes,
+    // Migration only runs when hasDemoState() is true (user has created or edited notes).
+    // Exclude unedited starters so only the user's real work migrates.
+    notes: state.notes.filter(
+      (n) => !STARTER_NOTE_IDS.has(n.localId) || hasStarterNoteBeenEdited(n)
+    ),
     tags: state.tags,
   };
 }


### PR DESCRIPTION
## Summary

7 items from the [design critique tracker](docs/active/design-critique-tracker.md) decided in discussion round:

- **feat: 404 page** — On-brand NotFoundPage ("This path leads nowhere. Your notes are waiting.") with lazy loading and URL-based route detection (#2)
- **fix: Demo starters visible on first visit** — Changed filtering logic so unedited starter notes show on fresh `/demo` visits; hidden once user starts writing (#10)
- **fix: CTA cluster breathing room** — Gap increased from 0.6rem to 1rem (#11b)
- **refactor: Auth.tsx inline styles → CSS classes** — 42 inline style objects reduced to 7; removed 5 hover handler pairs + 3 focus/blur handlers; added 12 CSS utility classes (#13)
- **fix: Standardize SVG strokeWidth to 1.5** — 59 instances across 21 files (#25)
- **fix: Search placeholder** — "Search..." → "Search your thoughts..." (#27)
- **docs: Styling convention** — Added to CLAUDE.md: Tailwind-first, inline for dynamic, `<style>` for complex (#24)

Also: 12 items closed as keep-as-is after discussion (#6-9, 11, 29-31, 33, 35, 37, 38). 2 items moved to backlog (#34, 36).

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm run test:run` — 905 pass, 2 pre-existing failures (offlineNotes, offlineTags)
- [ ] Visit `/nonexistent` — see 404 page with brand styling
- [ ] Visit `/demo` fresh — see all 4 starter notes
- [ ] Auth flows (login, signup, forgot password) — visually unchanged
- [ ] Landing page CTA has more breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
