### PR TITLE
fix: UI quiet sweep — unify logo, filter search, hush hovers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1104,8 +1104,8 @@ function App() {
     });
   }, [notes]);
 
-  // Determine which notes to display (tag-filtered only; search uses highlight, not filtering)
-  const displayNotes = useMemo(() => {
+  // Tag-filtered notes (pre-search baseline)
+  const tagFilteredNotes = useMemo(() => {
     if (selectedTagIds.length === 0) return sortedNotes;
 
     return sortedNotes.filter((note) => {
@@ -1553,7 +1553,7 @@ function App() {
 
   // Tag filter handlers
   const handleTagToggle = (tagId: string) => {
-    // Tag toggle preserves search query — matchedNoteIds recomputes via useEffect
+    // Tag toggle preserves search query — displayNotes re-filters via useMemo
     setSelectedTagIds((prev) =>
       prev.includes(tagId)
         ? prev.filter((id) => id !== tagId)
@@ -1682,20 +1682,17 @@ function App() {
     };
   }, []);
 
-  // Compute matchedNoteIds from debounced query (stable reference via useMemo)
-  const matchedNoteIds = useMemo(() => {
-    if (!debouncedSearchQuery.trim()) return undefined;
-    const q = debouncedSearchQuery.toLowerCase();
-    const matched = new Set<string>();
-    for (const note of displayNotes) {
-      const titleMatch = note.title.toLowerCase().includes(q);
-      const contentMatch = htmlToPlainText(note.content).toLowerCase().includes(q);
-      if (titleMatch || contentMatch) {
-        matched.add(note.id);
-      }
-    }
-    return matched;
-  }, [debouncedSearchQuery, displayNotes]);
+  // Apply debounced search on top of tag-filtered notes
+  const displayNotes = useMemo(() => {
+    const q = debouncedSearchQuery.trim().toLowerCase();
+    if (!q) return tagFilteredNotes;
+    return tagFilteredNotes.filter((note) => {
+      if (note.title.toLowerCase().includes(q)) return true;
+      return htmlToPlainText(note.content).toLowerCase().includes(q);
+    });
+  }, [debouncedSearchQuery, tagFilteredNotes]);
+
+  const isSearching = debouncedSearchQuery.trim().length > 0;
 
   // Export to JSON
   const handleExportJSON = useCallback(() => {
@@ -2296,8 +2293,6 @@ function App() {
           fadedNotesCount={fadedNotesCount}
           onRetryBlockedChanges={handleRetryBlockedChanges}
           isRetryingBlockedChanges={isRetryingBlockedChanges}
-          matchedCount={matchedNoteIds?.size}
-          totalCount={displayNotes.length}
         />
         <div id="main-content" className="w-full flex-1 flex flex-col" style={{ maxWidth: '1400px', margin: '0 auto' }}>
         <TagFilterBar
@@ -2316,7 +2311,7 @@ function App() {
           onNewNote={handleNewNote}
           onRefresh={handleRefresh}
           searchQuery={searchQuery}
-          matchedNoteIds={matchedNoteIds}
+          isSearching={isSearching}
         />
         </div>
 

--- a/src/components/ChapterSection.tsx
+++ b/src/components/ChapterSection.tsx
@@ -21,7 +21,7 @@ interface ChapterSectionProps {
   onTogglePin: (id: string, pinned: boolean) => void;
   isCompact?: boolean;
   searchQuery?: string;
-  matchedNoteIds?: Set<string>;
+  isSearching?: boolean;
 }
 
 // Visual treatment based on chapter age (subtle opacity reduction for older notes)
@@ -45,7 +45,7 @@ export const ChapterSection = memo(function ChapterSection({
   onTogglePin,
   isCompact = false,
   searchQuery,
-  matchedNoteIds,
+  isSearching = false,
 }: ChapterSectionProps) {
   // Detect touch capability for swipe gestures
   const isTouchDevice = useTouchCapable();
@@ -79,26 +79,23 @@ export const ChapterSection = memo(function ChapterSection({
     }
   }
 
-  // Search is "active" only after debounce settles (matchedNoteIds is defined)
-  const isSearchActive = matchedNoteIds !== undefined;
-
   // Determine if this section should be collapsible
   const isCollapsible = !isPinned && notes.length >= 20;
 
   // Force-expand during search so matches in collapsed chapters are visible
-  const effectiveExpanded = isSearchActive
+  const effectiveExpanded = isSearching
     ? true
     : isCollapsible
       ? isExpanded
       : true;
 
-  const displayNotes = isSearchActive ? notes : notes.slice(0, visibleCount);
-  const hasMore = !isSearchActive && visibleCount < notes.length;
+  const displayNotes = isSearching ? notes : notes.slice(0, visibleCount);
+  const hasMore = !isSearching && visibleCount < notes.length;
   const remainingCount = Math.max(0, notes.length - visibleCount);
 
   // IntersectionObserver for progressive loading
   useEffect(() => {
-    if (!sentinelRef.current || isSearchActive) return;
+    if (!sentinelRef.current || isSearching) return;
 
     readyRef.current = false;
     const sentinel = sentinelRef.current;
@@ -147,7 +144,7 @@ export const ChapterSection = memo(function ChapterSection({
       clearTimeout(timer);
       if (rafId) cancelAnimationFrame(rafId);
     };
-  }, [isSearchActive, notes.length, fingerprint, effectiveExpanded]);
+  }, [isSearching, notes.length, fingerprint, effectiveExpanded]);
 
   const opacity = CHAPTER_OPACITY[chapterKey];
 
@@ -176,19 +173,19 @@ export const ChapterSection = memo(function ChapterSection({
           flex items-center
           px-6 md:px-12
           py-1
-          ${isCollapsible && !isSearchActive ? 'cursor-pointer hover:bg-[var(--color-bg-secondary)] transition-colors duration-200' : ''}
+          ${isCollapsible && !isSearching ? 'cursor-pointer hover:bg-[var(--color-bg-secondary)] transition-colors duration-200' : ''}
         `}
         style={{
           borderLeft: '2px solid var(--color-accent-muted)',
           marginLeft: '1rem',
           paddingLeft: 'calc(1.5rem - 2px)',
         }}
-        onClick={isCollapsible && !isSearchActive ? () => setIsExpanded(!isExpanded) : undefined}
-        role={isCollapsible && !isSearchActive ? 'button' : undefined}
-        aria-expanded={isCollapsible && !isSearchActive ? effectiveExpanded : undefined}
-        aria-controls={isCollapsible && !isSearchActive ? `chapter-content-${chapterKey}` : undefined}
-        tabIndex={isCollapsible && !isSearchActive ? 0 : undefined}
-        onKeyDown={isCollapsible && !isSearchActive ? (e) => {
+        onClick={isCollapsible && !isSearching ? () => setIsExpanded(!isExpanded) : undefined}
+        role={isCollapsible && !isSearching ? 'button' : undefined}
+        aria-expanded={isCollapsible && !isSearching ? effectiveExpanded : undefined}
+        aria-controls={isCollapsible && !isSearching ? `chapter-content-${chapterKey}` : undefined}
+        tabIndex={isCollapsible && !isSearching ? 0 : undefined}
+        onKeyDown={isCollapsible && !isSearching ? (e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setIsExpanded(!isExpanded);
@@ -197,7 +194,7 @@ export const ChapterSection = memo(function ChapterSection({
       >
         {/* Label with optional chevron for collapsible sections */}
         <div className="flex items-center gap-2 shrink-0">
-          {isCollapsible && !isSearchActive && (
+          {isCollapsible && !isSearching && (
             <svg
               className={`
                 w-3 h-3
@@ -273,41 +270,35 @@ export const ChapterSection = memo(function ChapterSection({
             className="masonry-grid px-6 md:px-12"
             columnClassName="masonry-grid-column"
           >
-            {displayNotes.map((note, index) => {
-              const isFaded = isSearchActive && matchedNoteIds && !matchedNoteIds.has(note.id);
-              const isMatch = isSearchActive && matchedNoteIds && matchedNoteIds.has(note.id);
-
-              return (
-                <div
-                  key={note.id}
-                  className={`note-card-entrance${isFaded ? ' note-card-search-fade' : ''}${isMatch ? ' note-card-search-match' : ''}`}
-                  style={{
-                    animationDelay: `${Math.min(index * 0.06, 0.6)}s`,
-                  }}
-                  {...(isFaded ? { 'aria-hidden': true, inert: true } : {})}
-                >
-                  {isTouchDevice ? (
-                    <SwipeableNoteCard
-                      note={note}
-                      onClick={onNoteClick}
-                      onDelete={onNoteDelete}
-                      onTogglePin={onTogglePin}
-                      isCompact={isCompact}
-                      searchQuery={isMatch ? searchQuery : undefined}
-                    />
-                  ) : (
-                    <NoteCard
-                      note={note}
-                      onClick={onNoteClick}
-                      onDelete={onNoteDelete}
-                      onTogglePin={onTogglePin}
-                      isCompact={isCompact}
-                      searchQuery={isMatch ? searchQuery : undefined}
-                    />
-                  )}
-                </div>
-              );
-            })}
+            {displayNotes.map((note, index) => (
+              <div
+                key={note.id}
+                className="note-card-entrance"
+                style={{
+                  animationDelay: `${Math.min(index * 0.06, 0.6)}s`,
+                }}
+              >
+                {isTouchDevice ? (
+                  <SwipeableNoteCard
+                    note={note}
+                    onClick={onNoteClick}
+                    onDelete={onNoteDelete}
+                    onTogglePin={onTogglePin}
+                    isCompact={isCompact}
+                    searchQuery={isSearching ? searchQuery : undefined}
+                  />
+                ) : (
+                  <NoteCard
+                    note={note}
+                    onClick={onNoteClick}
+                    onDelete={onNoteDelete}
+                    onTogglePin={onTogglePin}
+                    isCompact={isCompact}
+                    searchQuery={isSearching ? searchQuery : undefined}
+                  />
+                )}
+              </div>
+            ))}
           </Masonry>
 
           {/* Sentinel for IntersectionObserver */}
@@ -333,7 +324,7 @@ export const ChapterSection = memo(function ChapterSection({
   prev.isPinned === next.isPinned &&
   prev.isCompact === next.isCompact &&
   prev.searchQuery === next.searchQuery &&
-  prev.matchedNoteIds === next.matchedNoteIds &&
+  prev.isSearching === next.isSearching &&
   prev.onNoteClick === next.onNoteClick &&
   prev.onNoteDelete === next.onNoteDelete &&
   prev.onTogglePin === next.onTogglePin

--- a/src/components/ChapteredLibrary.tsx
+++ b/src/components/ChapteredLibrary.tsx
@@ -23,7 +23,7 @@ interface ChapteredLibraryProps {
   onNewNote?: () => void;
   onRefresh?: () => Promise<void>;
   searchQuery?: string;
-  matchedNoteIds?: Set<string>;
+  isSearching?: boolean;
 }
 
 export function ChapteredLibrary({
@@ -34,7 +34,7 @@ export function ChapteredLibrary({
   onNewNote,
   onRefresh,
   searchQuery,
-  matchedNoteIds,
+  isSearching = false,
 }: ChapteredLibraryProps) {
   // Auto-detect compact mode based on viewport width (mobile = compact)
   const [isCompact, setIsCompact] = useState(() => {
@@ -123,8 +123,36 @@ export function ChapteredLibrary({
     return chapters.map((c) => ({ key: c.key as ChapterKey, label: c.label }));
   }, [chapters]);
 
-  // Is search active with no matches?
-  const isSearchNoMatches = !!(searchQuery && searchQuery.trim().length > 0 && matchedNoteIds && matchedNoteIds.size === 0);
+  // Search-active empty state — show distinct "No thoughts found" message
+  if (notes.length === 0 && isSearching) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center">
+          <p
+            className="text-2xl mb-3"
+            style={{
+              fontFamily: 'var(--font-display)',
+              color: 'var(--color-text-primary)',
+              fontWeight: 400,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            No thoughts found
+          </p>
+          <p
+            className="text-base"
+            style={{
+              fontFamily: 'var(--font-body)',
+              color: 'var(--color-text-tertiary)',
+              lineHeight: 1.6,
+            }}
+          >
+            Try a different search
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   // Empty state (no notes at all)
   if (notes.length === 0) {
@@ -245,27 +273,9 @@ export function ChapteredLibrary({
           onTogglePin={onTogglePin}
           isCompact={isCompact}
           searchQuery={searchQuery}
-          matchedNoteIds={matchedNoteIds}
+          isSearching={isSearching}
         />
       ))}
-
-      {/* "No thoughts found" overlay — centered on faded library */}
-      {isSearchNoMatches && (
-        <div
-          className="absolute inset-0 flex items-center justify-center pointer-events-none"
-          style={{ zIndex: 5 }}
-        >
-          <p
-            className="text-lg"
-            style={{
-              fontFamily: 'var(--font-display)',
-              color: 'var(--color-text-secondary)',
-            }}
-          >
-            No thoughts found
-          </p>
-        </div>
-      )}
     </main>
   );
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -792,7 +792,7 @@ export function Editor({ note, tags, userId, onBack, onRequestSearch, onUpdate, 
   const leftContent = (
     <div className="flex items-center min-w-0">
       {/* Clickable Logo */}
-      <Logo onClick={handleLogoClick} variant="editor" className="shrink-0" />
+      <Logo onClick={handleLogoClick} className="shrink-0" />
 
       {/* Separator - visible on desktop */}
       <span

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,8 +23,6 @@ interface HeaderProps {
   fadedNotesCount: number;
   onRetryBlockedChanges?: () => Promise<void>;
   isRetryingBlockedChanges?: boolean;
-  matchedCount?: number;
-  totalCount?: number;
 }
 
 export function Header({
@@ -42,8 +40,6 @@ export function Header({
   fadedNotesCount,
   onRetryBlockedChanges,
   isRetryingBlockedChanges = false,
-  matchedCount,
-  totalCount,
 }: HeaderProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -199,20 +195,6 @@ export function Header({
           )}
         </div>
 
-        {/* Search result count */}
-        {searchQuery && matchedCount !== undefined && totalCount !== undefined && (
-          <p
-            className="text-center mt-1"
-            style={{
-              fontFamily: 'var(--font-body)',
-              color: 'var(--color-text-tertiary)',
-              fontSize: '0.7rem',
-            }}
-            aria-live="polite"
-          >
-            {matchedCount} of {totalCount} thoughts
-          </p>
-        )}
       </div>
     </div>
   );

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -3,7 +3,7 @@ import lockup1200 from '../assets/brand/yidhan-logo-lockup-tight-1200.webp';
 import mark256 from '../assets/brand/yidhan-logo-mark-256.webp';
 import mark512 from '../assets/brand/yidhan-logo-mark-512.webp';
 
-type LogoVariant = 'header' | 'hero' | 'auth' | 'editor';
+type LogoVariant = 'header' | 'hero' | 'auth';
 
 interface LogoProps {
   className?: string;
@@ -24,23 +24,13 @@ const lockupSizes: Record<'hero' | 'auth', string> = {
   auth: '(max-width: 640px) 150px, 178px',
 };
 
-const compactImageClasses: Record<'header' | 'editor', string> = {
-  header: 'h-[26px] sm:h-[30px]',
-  editor: 'h-[23px] sm:h-[26px]',
-};
-
-const compactWordClasses: Record<'header' | 'editor', string> = {
-  header: 'text-[1.7rem] sm:text-[1.95rem] -ml-[0.16rem] sm:-ml-[0.2rem]',
-  editor: 'text-[1.52rem] sm:text-[1.68rem] -ml-[0.14rem] sm:-ml-[0.18rem]',
-};
-
-const compactImageSizes: Record<'header' | 'editor', string> = {
-  header: '(max-width: 640px) 26px, 30px',
-  editor: '(max-width: 640px) 23px, 26px',
-};
+const compactImageClass = 'h-[26px] sm:h-[30px]';
+const compactWordClass =
+  'text-[1.7rem] sm:text-[1.95rem] -ml-[0.16rem] sm:-ml-[0.2rem]';
+const compactImageSizes = '(max-width: 640px) 26px, 30px';
 
 const buttonClassName =
-  'inline-flex items-center rounded-[14px] motion-safe:transition-transform motion-safe:duration-200 motion-safe:hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]';
+  'inline-flex items-center rounded-[14px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]';
 
 function isLockupVariant(variant: LogoVariant): variant is 'hero' | 'auth' {
   return variant === 'hero' || variant === 'auth';
@@ -101,10 +91,10 @@ export function Logo({
     <img
       src={mark512}
       srcSet={`${mark256} 256w, ${mark512} 512w`}
-      sizes={compactImageSizes[variant]}
+      sizes={compactImageSizes}
       alt=""
       aria-hidden="true"
-      className={`${compactImageClasses[variant]} w-auto shrink-0 select-none ${imageClassName}`.trim()}
+      className={`${compactImageClass} w-auto shrink-0 select-none ${imageClassName}`.trim()}
       decoding="async"
       loading={priority ? 'eager' : 'lazy'}
       fetchPriority={priority ? 'high' : 'auto'}
@@ -115,7 +105,7 @@ export function Logo({
 
   const compactWord = (
     <span
-      className={`${compactWordClasses[variant]} leading-none tracking-[-0.045em]`.trim()}
+      className={`${compactWordClass} leading-none tracking-[-0.045em]`.trim()}
       style={{
         fontFamily: 'var(--font-display)',
         color: 'color-mix(in srgb, var(--color-text-primary) 90%, var(--color-accent) 10%)',

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -110,10 +110,12 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         }
       }}
       onMouseEnter={(e) => {
-        e.currentTarget.style.transform = 'translateY(-3px)';
+        if (!isCompact) {
+          e.currentTarget.style.boxShadow = 'var(--shadow-lg)';
+        }
       }}
       onMouseLeave={(e) => {
-        e.currentTarget.style.transform = 'translateY(0)';
+        e.currentTarget.style.boxShadow = isCompact ? 'var(--shadow-sm)' : 'var(--shadow-md)';
       }}
     >
       {/* Pin button - top-right corner (only in full mode) */}
@@ -125,29 +127,16 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
             w-10 h-10
             rounded-full
             flex items-center justify-center
-            transition-all duration-200
+            transition-opacity duration-200
             focus:outline-none
             focus:ring-2
             focus:ring-[var(--color-accent)]
-            focus:opacity-100
-            hover:scale-110
-            ${note.pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}
+            focus-visible:opacity-100
+            ${note.pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-40 hover:!opacity-85'}
           `}
           style={{
-            background: note.pinned ? 'var(--color-accent-glow)' : 'var(--color-bg-secondary)',
+            background: note.pinned ? 'var(--color-accent-glow)' : 'transparent',
             color: note.pinned ? 'var(--color-accent-muted)' : 'var(--color-text-tertiary)',
-          }}
-          onMouseEnter={(e) => {
-            if (!note.pinned) {
-              e.currentTarget.style.color = 'var(--color-accent)';
-              e.currentTarget.style.background = 'color-mix(in srgb, var(--color-accent) 10%, transparent)';
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (!note.pinned) {
-              e.currentTarget.style.color = 'var(--color-text-tertiary)';
-              e.currentTarget.style.background = 'var(--color-bg-secondary)';
-            }
           }}
           aria-label={note.pinned ? 'Unpin note' : 'Pin note'}
           title={note.pinned ? 'Unpin note' : 'Pin note'}
@@ -260,28 +249,20 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
               rounded-full
               flex items-center justify-center
               opacity-0
-              group-hover:opacity-100
-              transition-all duration-200
+              group-hover:opacity-40
+              hover:!opacity-85
+              transition-opacity duration-200
               focus:outline-none
               focus:ring-2
               focus:ring-[var(--color-accent)]
-              focus:opacity-100
-              hover:scale-110
+              focus-visible:opacity-100
               ml-2
               -mr-2
               shrink-0
             "
             style={{
-              background: 'var(--color-bg-secondary)',
+              background: 'transparent',
               color: 'var(--color-text-tertiary)',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = 'var(--color-destructive)';
-              e.currentTarget.style.background = 'var(--color-error-light)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = 'var(--color-text-tertiary)';
-              e.currentTarget.style.background = 'var(--color-bg-secondary)';
             }}
             aria-label="Delete note"
             title="Delete note"

--- a/src/index.css
+++ b/src/index.css
@@ -434,20 +434,6 @@ body::before {
   animation: rising-wave 0.2s var(--ease-out-quint) backwards;
 }
 
-/* Search: fade non-matching cards */
-.note-card-search-fade {
-  opacity: 0.12;
-  pointer-events: none;
-  transition: opacity 200ms ease;
-}
-
-/* Search: highlight matching cards */
-.note-card-search-match {
-  transform: scale(1.02);
-  transition: transform 200ms ease, filter 200ms ease;
-  filter: drop-shadow(0 0 8px var(--color-accent-glow));
-}
-
 /* Waterline affordance */
 .waterline {
   position: relative;

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -118,8 +118,8 @@ export function DemoPage({
     return notes.find((n) => n.id === selectedNoteId) ?? null;
   }, [notes, selectedNoteId]);
 
-  // Determine which notes to display (tag-filtered only; search uses highlight, not filtering)
-  const displayNotes = useMemo(() => {
+  // Tag-filtered notes (pre-search baseline)
+  const tagFilteredNotes = useMemo(() => {
     if (selectedTagIds.length === 0) return notes;
 
     return notes.filter((note) => {
@@ -128,7 +128,7 @@ export function DemoPage({
     });
   }, [notes, selectedTagIds]);
 
-  // Debounced search handler (focused-gaze: highlights, doesn't filter)
+  // Debounced search handler
   const handleSearchChange = useCallback((query: string) => {
     setSearchQuery(query);
 
@@ -155,20 +155,17 @@ export function DemoPage({
     };
   }, []);
 
-  // Compute matchedNoteIds from debounced query (stable reference via useMemo)
-  const matchedNoteIds = useMemo(() => {
-    if (!debouncedSearchQuery.trim()) return undefined;
-    const q = debouncedSearchQuery.toLowerCase();
-    const matched = new Set<string>();
-    for (const note of displayNotes) {
-      const titleMatch = note.title.toLowerCase().includes(q);
-      const contentMatch = htmlToPlainText(note.content).toLowerCase().includes(q);
-      if (titleMatch || contentMatch) {
-        matched.add(note.id);
-      }
-    }
-    return matched;
-  }, [debouncedSearchQuery, displayNotes]);
+  // Apply debounced search on top of tag-filtered notes
+  const displayNotes = useMemo(() => {
+    const q = debouncedSearchQuery.trim().toLowerCase();
+    if (!q) return tagFilteredNotes;
+    return tagFilteredNotes.filter((note) => {
+      if (note.title.toLowerCase().includes(q)) return true;
+      return htmlToPlainText(note.content).toLowerCase().includes(q);
+    });
+  }, [debouncedSearchQuery, tagFilteredNotes]);
+
+  const isSearching = debouncedSearchQuery.trim().length > 0;
 
   // Handlers - defined before effects that use them
   const handleNewNote = useCallback(() => {
@@ -258,7 +255,7 @@ export function DemoPage({
 
   // Tag filter handlers
   const handleTagToggle = (tagId: string) => {
-    // Tag toggle preserves search query — matchedNoteIds recomputes via useMemo
+    // Tag toggle preserves search query — displayNotes re-filters via useMemo
     setSelectedTagIds((prev) =>
       prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]
     );
@@ -394,8 +391,6 @@ export function DemoPage({
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
           onSignIn={onSignIn}
-          matchedCount={matchedNoteIds?.size}
-          totalCount={displayNotes.length}
         />
 
         <div
@@ -461,7 +456,7 @@ export function DemoPage({
           onTogglePin={handleTogglePin}
           onNewNote={handleNewNote}
           searchQuery={searchQuery}
-          matchedNoteIds={matchedNoteIds}
+          isSearching={isSearching}
         />
         </div>
 
@@ -492,8 +487,6 @@ interface DemoHeaderProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onSignIn: () => void;
-  matchedCount?: number;
-  totalCount?: number;
 }
 
 function DemoHeader({
@@ -504,8 +497,6 @@ function DemoHeader({
   searchQuery,
   onSearchChange,
   onSignIn,
-  matchedCount,
-  totalCount,
 }: DemoHeaderProps) {
   const searchRef = useRef<HTMLInputElement>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -655,20 +646,6 @@ function DemoHeader({
               )}
             </div>
 
-            {/* Search result count */}
-            {searchQuery && matchedCount !== undefined && totalCount !== undefined && (
-              <p
-                className="text-center mt-1"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  color: 'var(--color-text-tertiary)',
-                  fontSize: '0.7rem',
-                }}
-                aria-live="polite"
-              >
-                {matchedCount} of {totalCount} thoughts
-              </p>
-            )}
           </div>
         </div>
       }


### PR DESCRIPTION
## Summary
Four UI calmness fixes prompted by hands-on use:

- **Logo unified across pages** — editor was using a smaller `editor` variant; now uses the same `header` variant as library/auth/landing/404. Also removed the hover lift so the logo stays still.
- **Search filters instead of fading** — the focused-gaze model (fade non-matches to 12%, all cards stay in place) was visually noisy in practice. Now filters `displayNotes`; new "No thoughts found / Try a different search" empty state distinguishes search-empty from library-empty. Removed the "X of Y thoughts" counter that caused layout shift below the search bar.
- **NoteCard hover quieter** — no more 3px translateY; just shadow deepening (md → lg).
- **Pin/delete buttons quieter** — fade to 40% on card hover, 85% on direct button hover; dropped scale-110 and the red destructive flash for delete.

## Test plan
- [ ] Editor and library logos visually identical (size, position, no lift on hover)
- [ ] Search shows only matching notes; layout above search bar doesn't shift when typing
- [ ] Search with no matches shows "No thoughts found" (not "Your notes await")
- [ ] Card hover deepens shadow without moving
- [ ] Delete/pin buttons fade in calmly, no scale, no red flash on delete hover
- [x] `npm run check` passes (typecheck + lint + 913 tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anbuneel/yidhan/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->