### PR TITLE
feat: reimagine landing page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
+- Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
 - Demo-to-account migration runs on signup in `App.tsx` via `migrateDemoToAccount()` (creates encrypted notes)
 
 ## UI Layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
+- Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
 - Demo-to-account migration runs on signup in `App.tsx` via `migrateDemoToAccount()` (creates encrypted notes)
 
 ## UI Layout

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A calm, distraction-free note-taking app — where thoughts bloom with clarity.
 - **Light & Dark Themes** - Kintsugi (warm light) and Midnight (forest green dark) themes
 - **Tag Organization** - Organize notes with colorful tags and filter by multiple tags
 - **Tag Management** - Create, edit, and delete tags with a beautiful color picker
-- **Landing Page** - Unified single-canvas composition with manuscript preview matching the real editor, staggered entrance animations, and horizontal text reveal
+- **Landing Page** - Quiet hero that becomes a lightweight writing surface on desktop, saves the first draft into signup, and follows with a real-product gallery
 - **Practice Space** - Full-featured demo at `/demo` without signup; notes persist in localStorage
 - **Seamless Onboarding** - Demo content auto-saves after signup, email confirmation with resend options
 - **Export/Import** - Backup notes to JSON or Markdown, restore from backups
@@ -175,7 +175,7 @@ src/
 │   ├── EditorToolbar.tsx  # Sticky formatting toolbar
 │   ├── ErrorBoundary.tsx  # Error boundary for graceful error handling
 │   ├── Footer.tsx         # Footer with changelog/roadmap/GitHub links
-│   ├── LandingPage.tsx    # Split-screen landing with interactive demo
+│   ├── LandingPage.tsx    # Landing hero/editor reveal with product gallery
 │   ├── Header.tsx         # App header with search, profile menu
 │   ├── Library.tsx        # Notes grid view
 │   ├── SimpleHeader.tsx   # Simple header with clickable logo

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -205,17 +205,21 @@ Zenote aims to be the antithesis of feature-bloated productivity tools. Where ot
 ### 1. New User Onboarding
 
 ```
-Landing Page → "Start Writing" CTA → Auth Modal (Sign Up)
+Landing Page → "Start writing" CTA → Desktop hero writing surface
+                                      Mobile Practice Space (/demo)
                                             ↓
-                                    Email Confirmation
+                         "Continue in Yidhan" / Sign Up
                                             ↓
-                                    Library (with welcome note)
+                                    Email Confirmation + vault unlock
+                                            ↓
+                    Library/editor with encrypted migrated first note
 ```
 
-**Demo-to-Signup Flow:**
-- User types in demo editor on landing page
-- "Save this note" CTA appears after typing
-- Demo content auto-migrates as first note after signup
+**Landing Draft-to-Signup Flow:**
+- On desktop, user types in the lightweight landing manuscript surface
+- "Continue in Yidhan" appears after typing and saves the draft locally under `yidhan-demo-content`
+- After signup and vault unlock, `App.tsx` migrates that draft into an encrypted "My first note"
+- On mobile, the primary CTA routes to Practice Space instead of opening the in-place editor
 
 ### 1b. Practice Space Flow (New)
 

--- a/docs/ui-layout.md
+++ b/docs/ui-layout.md
@@ -2,64 +2,90 @@
 
 Detailed ASCII diagrams for UI components. Referenced from CLAUDE.md for detailed layout work.
 
-## Landing Page (Split-Screen)
+## Landing Page (Hero Becomes Editor)
 
-**Desktop (≥768px):**
+**Desktop (>=768px), initial hero:**
 ```
-┌─────────────────────────────────┬─────────────────────────────────────────────┐
-│ Yidhan                          │                          [🌙] [Sign In]     │
-├─────────────────────────────────┼─────────────────────────────────────────────┤
-│                                 │  ┌─────────────┐  ┌─────────────┐          │
-│  A quiet space                  │  │ Sample Note │  │ Sample Note │          │
-│  for your notes.                │  │ [tag] TIME  │  │ [tag] TIME  │          │
-│                                 │  └─────────────┘  └─────────────┘          │
-│  The distraction-free...        │  ┌─────────────┐  ┌─────────────┐          │
-│                                 │  │ Sample Note │  │ Sample Note │          │
-│  [Start Writing]  For free      │  │ [tag] TIME  │  │ [tag] TIME  │          │
-│                                 │  └─────────────┘  └─────────────┘          │
-│  or explore without signing up→ │                                            │
-│                                 │                                            │
-│  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─         │                                            │
-│  ✦ Open source                  │                                            │
-│  ✦ Works offline                │                                            │
-│  ✦ Your data stays yours        │                                            │
-└─────────────────────────────────┴─────────────────────────────────────────────┘
++--------------------------------------------------------------------------+
+| Yidhan                                               [theme] [Sign In]   |
++--------------------------------------------------------------------------+
+|                                                                          |
+|                         Begin where you are.                             |
+|                                                                          |
+|      A quiet space for the half-formed thought. No folders. No tags.     |
+|      Nothing to learn -- just room to think.                              |
+|                                                                          |
+|                         [ Start writing ]                                |
+|                         No account needed to start.                      |
+|                         Explore the Practice Space ->                    |
+|                                                                          |
+|                         Or see how it feels                               |
+|                                  v                                       |
++--------------------------------------------------------------------------+
+```
+
+**Desktop, after Start writing:**
+```
++--------------------------------------------------------------------------+
+| Yidhan                                               [theme] [Sign In]   |
++--------------------------------------------------------------------------+
+|                                                                          |
+|               +--------------------------------------------------+       |
+|               |                                                  |       |
+|               |  Begin where you are...                          |       |
+|               |                                                  |       |
+|               |                                                  |       |
+|               |  Locked before it leaves your hands.             |       |
+|               |                         [Continue in Yidhan ->]  |       |
+|               +--------------------------------------------------+       |
+|                                                                          |
++--------------------------------------------------------------------------+
+```
+
+**Gallery second act:**
+```
++--------------------------------------------------------------------------+
+| The surface                                                              |
+| A page that gets out of the way.                    [editor surface]      |
+|                                                                          |
+| What accumulates                                                         |
+| [real starter note card masonry]                    Your thoughts...      |
+|                                                                          |
+| What stays yours                                                         |
+| Locked before it leaves your hands.                 [vault mark]          |
+|                                                                          |
+| Your page is waiting.                               [Start writing]       |
+| Changelog . Roadmap . GitHub . Privacy . Terms . Support                 |
++--------------------------------------------------------------------------+
 ```
 
 **Mobile (<768px):**
 ```
-┌─────────────────────────────────┐
-│ Yidhan            [🌙] [Sign In]│
-├─────────────────────────────────┤
-│                                 │
-│   A quiet space                 │
-│   for your notes.               │
-│                                 │
-│   [Start Writing]  For free     │
-│                                 │
-│   or explore first →            │
-│                                 │
-│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─        │
-│   ✦ Open source                 │
-│   ✦ Works offline               │
-│   ✦ Your data stays yours       │
-│                                 │
-│   ┌─────────────────────────┐   │
-│   │ Sample Note             │   │
-│   │ [tag]            TIME   │   │
-│   └─────────────────────────┘   │
-│                                 │
-│   Changelog · Roadmap · GitHub  │
-└─────────────────────────────────┘
++---------------------------------+
+| Yidhan          [theme] [Sign In]|
++---------------------------------+
+|                                 |
+|       Begin where you are.      |
+|                                 |
+|   A quiet space for the         |
+|   half-formed thought.          |
+|                                 |
+|       [ Start writing ]         |  -> routes to /demo
+|       No account needed         |
+|       Explore Practice Space -> |
+|                                 |
+|   (gallery follows below)       |
+|                                 |
++---------------------------------+
 ```
 
-- True 50-50 split on desktop (each panel has its own header)
-- Left panel: Hero + CTA + secondary "explore" link + trust signals
-- Right panel: 4 static sample note cards in 2x2 grid (no interactive demo)
-- Secondary CTA links to /demo (Practice Space / "Explore" mode)
-- Trust signals: Open source, Works offline, Your data stays yours
-- Auth opens as modal overlay (responsive, scrollable on mobile)
-- Mobile: Stacked layout with single sample card
+- Desktop primary CTA reveals a lightweight `contentEditable` manuscript in place.
+- The first typed draft is saved to `yidhan-demo-content` before signup and migrated by `App.tsx` into an encrypted "My first note" after auth/unlock.
+- Hidden hero controls and scroll cue leave the tab order after the editor reveal.
+- Mobile primary CTA routes directly to `/demo` to avoid soft-keyboard viewport shifts.
+- Gallery uses three museum-spaced proof pieces: writing surface, starter-note grid, and encryption/offline/open-source promise.
+- Gallery starter notes mirror the Practice Space seed notes.
+- Auth opens as modal overlay from `Continue in Yidhan`.
 
 ## Auth Modal (OAuth-First Layout)
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -11,22 +11,26 @@ test.describe('Authentication', () => {
 
   test.describe('Landing Page', () => {
     test('shows landing page for unauthenticated users', async ({ page }) => {
-      await expect(page.getByRole('heading', { name: /a quiet space/i })).toBeVisible();
-      await expect(page.getByRole('button', { name: /start writing/i })).toBeVisible();
+      await expect(page.getByRole('heading', { name: /begin where you are/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: /start writing/i }).first()).toBeVisible();
       await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
     });
 
-    test('has interactive demo editor', async ({ page }) => {
-      const demoEditor = page.getByTestId('demo-editor');
-      await expect(demoEditor).toBeVisible();
+    test('starts writing from the landing page', async ({ page }) => {
+      await page.getByRole('button', { name: /start writing/i }).first().click();
 
-      // Type in demo
-      await demoEditor.click();
-      await page.keyboard.type('Testing the demo editor');
+      const isMobileViewport = (page.viewportSize()?.width ?? 0) <= 768;
+      if (isMobileViewport) {
+        await expect(page).toHaveURL(/\/demo/);
+        await expect(page.getByRole('heading', { name: /practice space/i })).toBeVisible();
+        return;
+      }
 
-      // Should persist (localStorage)
-      await page.reload();
-      await expect(page.getByText('Testing the demo editor')).toBeVisible();
+      const landingEditor = page.getByRole('textbox', { name: /your writing/i });
+      await expect(landingEditor).toBeVisible();
+      await landingEditor.fill('Testing the landing editor');
+      await expect(page.locator('.landing-seal')).toBeVisible();
+      await expect(page.getByRole('button', { name: /continue in yidhan/i })).toBeVisible();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cap:sync": "npm run build && npx cap sync",
     "cap:android": "npm run build && npx cap sync android && npx cap open android",
     "cap:android:run": "npm run build && npx cap sync android && npx cap run android",
-    "doctor": "npx react-doctor@latest"
+    "doctor": "npx -y react-doctor@0.4.2 --no-telemetry"
   },
   "dependencies": {
     "@capacitor/android": "^8.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,7 @@ import {
   ValidationError,
   MAX_IMPORT_FILE_SIZE,
 } from './utils/exportImport';
-import { hasDemoState } from './services/demoStorage';
+import { DEMO_CONTENT_STORAGE_KEY, hasDemoState } from './services/demoStorage';
 import { migrateDemoToAccount } from './services/demoMigration';
 import { sanitizeHtml } from './utils/sanitize';
 import { useNetworkStatus } from './hooks/useNetworkStatus';
@@ -120,8 +120,6 @@ import { IOSInstallGuide } from './components/IOSInstallGuide';
 import { SessionTimeoutModal } from './components/SessionTimeoutModal';
 import { reportReliabilityIssue } from './utils/reliabilityTelemetry';
 import './App.css';
-
-const DEMO_STORAGE_KEY = 'yidhan-demo-content';
 
 /**
  * Migrate localStorage keys from old 'zenote-' prefix to new 'yidhan-' prefix
@@ -989,11 +987,14 @@ function App() {
   // 2. We only care about identity (userId), not other user metadata
   // 3. String comparison is stable; object reference changes on every auth state update
   useEffect(() => {
-    if (!userId || hasMigratedDemoContent.current) return;
+    if (!userId) {
+      hasMigratedDemoContent.current = false;
+      return;
+    }
+    if (hasMigratedDemoContent.current) return;
 
-    const demoContent = localStorage.getItem(DEMO_STORAGE_KEY);
+    const demoContent = localStorage.getItem(DEMO_CONTENT_STORAGE_KEY);
     if (!demoContent?.trim()) {
-      hasMigratedDemoContent.current = true;
       return;
     }
 
@@ -1010,9 +1011,9 @@ function App() {
     createEncryptedNote(userId, 'My first note', htmlContent, keys)
       .then((newNote) => {
         // Clear demo content from localStorage
-        localStorage.removeItem(DEMO_STORAGE_KEY);
+        localStorage.removeItem(DEMO_CONTENT_STORAGE_KEY);
         // Show toast notification
-        toast.success('Your demo note has been saved!');
+        toast.success('Your first note has been saved!');
         // Add to notes list
         setNotes((prev) => [newNote, ...prev]);
         // Open the note in editor
@@ -1034,7 +1035,11 @@ function App() {
   useEffect(() => {
     // Gate on hydration complete to avoid race conditions
     if (isHydrating) return;
-    if (!userId || hasMigratedDemoNotes.current) return;
+    if (!userId) {
+      hasMigratedDemoNotes.current = false;
+      return;
+    }
+    if (hasMigratedDemoNotes.current) return;
 
     // Wait for encryption keys before migrating — without this,
     // migrateDemoToAccount would create plaintext notes via createNoteOffline

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo, type MouseEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo, type ClipboardEvent, type MouseEvent } from 'react';
 import { useInstallPrompt } from '../hooks/useInstallPrompt';
 import { HeaderShell } from './HeaderShell';
 import { createDemoStarterPreviewState, DEMO_CONTENT_STORAGE_KEY } from '../services/demoStorage';
@@ -17,6 +17,14 @@ interface LandingPageProps {
   onTermsClick: () => void;
   onSupportClick: () => void;
 }
+
+const isMobileViewport = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(max-width: 768px)').matches === true;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
 export function LandingPage({
   onStartWriting,
@@ -72,14 +80,6 @@ export function LandingPage({
   const focusTimeoutRef = useRef<number | null>(null);
   const closeStartTimeoutRef = useRef<number | null>(null);
 
-  const isMobile = () =>
-    typeof window !== 'undefined' &&
-    window.matchMedia?.('(max-width: 768px)').matches === true;
-
-  const prefersReducedMotion = () =>
-    typeof window !== 'undefined' &&
-    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
-
   const enterWriting = useCallback(() => {
     const activeElement = document.activeElement;
     if (
@@ -101,7 +101,7 @@ export function LandingPage({
   }, []);
 
   const handleStartWriting = () => {
-    if (isMobile()) {
+    if (isMobileViewport()) {
       onDemoClick();
       return;
     }
@@ -109,7 +109,7 @@ export function LandingPage({
   };
 
   const handleCloseStart = () => {
-    if (isMobile()) {
+    if (isMobileViewport()) {
       onDemoClick();
       return;
     }
@@ -135,6 +135,15 @@ export function LandingPage({
     hasEditedDraftRef.current = true;
     setHasWritten(text.length > 0);
     setDraftSaveError(false);
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const text = event.clipboardData.getData('text/plain');
+    if (!text) return;
+
+    document.execCommand('insertText', false, text);
+    handleInput();
   };
 
   const saveDraftBeforeAuth = () => {
@@ -166,9 +175,8 @@ export function LandingPage({
   };
 
   const handleSignIn = () => {
-    if (saveDraftBeforeAuth()) {
-      onSignIn();
-    }
+    setDraftSaveError(false);
+    onSignIn();
   };
 
   const handleDemoClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -273,23 +281,24 @@ export function LandingPage({
                 aria-multiline="true"
                 aria-label="Your writing"
                 spellCheck={isWriting}
+                data-empty={!hasWritten}
                 onInput={handleInput}
+                onPaste={handlePaste}
               />
               <div className="landing-hero-foot">
                 <span className={`landing-seal${hasWritten ? ' show' : ''}`}>
                   <span className="landing-seal-dot" aria-hidden="true" />
                   Locked before it leaves your hands.
                 </span>
-                <button
-                  type="button"
-                  onClick={handleContinue}
-                  className={`landing-continue focus-ring${hasWritten ? ' show' : ''}`}
-                  disabled={!hasWritten}
-                  aria-hidden={!hasWritten}
-                  tabIndex={hasWritten ? 0 : -1}
-                >
-                  Continue in Yidhan →
-                </button>
+                {hasWritten && (
+                  <button
+                    type="button"
+                    onClick={handleContinue}
+                    className="landing-continue focus-ring show"
+                  >
+                    Continue in Yidhan →
+                  </button>
+                )}
               </div>
               {draftSaveError && (
                 <p className="landing-draft-error" role="alert">
@@ -300,15 +309,15 @@ export function LandingPage({
           </div>
         </div>
 
-        <a
-          className="landing-scrollcue focus-ring"
-          href="#landing-surface"
-          aria-hidden={isWriting}
-          tabIndex={hiddenHeroTabIndex}
-        >
-          <span>Or see how it feels</span>
-          <span className="landing-scrollcue-arrow" aria-hidden="true">↓</span>
-        </a>
+        {!isWriting && (
+          <a
+            className="landing-scrollcue focus-ring"
+            href="#landing-surface"
+          >
+            <span>Or see how it feels</span>
+            <span className="landing-scrollcue-arrow" aria-hidden="true">↓</span>
+          </a>
+        )}
       </section>
 
       {/* ─── Gallery — the honest "second act": the real product ─── */}
@@ -591,7 +600,7 @@ export function LandingPage({
           overflow-wrap: anywhere;
           word-break: break-word;
         }
-        .landing-hero-doc:empty::before {
+        .landing-hero-doc[data-empty="true"]::before {
           content: "Begin where you are\\2026";
           color: var(--color-text-tertiary);
           font-style: italic;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,7 +1,9 @@
-import type { MouseEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo, type MouseEvent } from 'react';
 import { useInstallPrompt } from '../hooks/useInstallPrompt';
 import { HeaderShell } from './HeaderShell';
-import type { Theme } from '../types';
+import { createDemoStarterPreviewState, DEMO_CONTENT_STORAGE_KEY } from '../services/demoStorage';
+import { NoteCard } from './NoteCard';
+import type { Note, Tag, Theme } from '../types';
 
 interface LandingPageProps {
   onStartWriting: () => void;
@@ -29,7 +31,145 @@ export function LandingPage({
   onSupportClick,
 }: LandingPageProps) {
   const { isInstallable, isInstalled, triggerInstall } = useInstallPrompt();
-  const isDark = theme === 'dark';
+  const previewNotes = useMemo<Note[]>(() => {
+    const demoState = createDemoStarterPreviewState();
+    const tagsById = new Map<string, Tag>(
+      demoState.tags.map((tag) => [
+        tag.localId,
+        {
+          id: tag.localId,
+          name: tag.name,
+          color: tag.color,
+          createdAt: new Date(tag.createdAt),
+        },
+      ])
+    );
+
+    return demoState.notes.map((note) => ({
+      id: note.localId,
+      title: note.title,
+      content: note.content,
+      createdAt: new Date(note.createdAt),
+      updatedAt: new Date(note.updatedAt),
+      tags: note.tagIds
+        .map((tagId) => tagsById.get(tagId))
+        .filter((tag): tag is Tag => Boolean(tag)),
+      pinned: note.pinned,
+      deletedAt: null,
+      syncStatus: 'synced',
+    }));
+  }, []);
+
+  // The hero quietly becomes a real writing surface on desktop. On phones we
+  // route to the Practice Space instead — the in-place reveal fights the mobile
+  // keyboard (viewport shift), so we reserve the signature moment for desktop.
+  const [isWriting, setIsWriting] = useState(false);
+  const [hasWritten, setHasWritten] = useState(false);
+  const [draftSaveError, setDraftSaveError] = useState(false);
+  const landingRootRef = useRef<HTMLDivElement>(null);
+  const editableRef = useRef<HTMLDivElement>(null);
+  const hasEditedDraftRef = useRef(false);
+  const focusTimeoutRef = useRef<number | null>(null);
+  const closeStartTimeoutRef = useRef<number | null>(null);
+
+  const isMobile = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(max-width: 768px)').matches === true;
+
+  const prefersReducedMotion = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+
+  const enterWriting = useCallback(() => {
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      landingRootRef.current?.contains(activeElement)
+    ) {
+      activeElement.blur();
+    }
+
+    setIsWriting(true);
+    if (focusTimeoutRef.current !== null) {
+      window.clearTimeout(focusTimeoutRef.current);
+    }
+    const focusDelay = prefersReducedMotion() ? 0 : 360;
+    focusTimeoutRef.current = window.setTimeout(() => {
+      editableRef.current?.focus();
+      focusTimeoutRef.current = null;
+    }, focusDelay);
+  }, []);
+
+  const handleStartWriting = () => {
+    if (isMobile()) {
+      onDemoClick();
+      return;
+    }
+    enterWriting();
+  };
+
+  const handleCloseStart = () => {
+    if (isMobile()) {
+      onDemoClick();
+      return;
+    }
+    const reducedMotion = prefersReducedMotion();
+    window.scrollTo({ top: 0, behavior: reducedMotion ? 'auto' : 'smooth' });
+    if (closeStartTimeoutRef.current !== null) {
+      window.clearTimeout(closeStartTimeoutRef.current);
+    }
+    const revealDelay = reducedMotion ? 0 : 520;
+    closeStartTimeoutRef.current = window.setTimeout(() => {
+      enterWriting();
+      closeStartTimeoutRef.current = null;
+    }, revealDelay);
+  };
+
+  const getDraftText = () => {
+    const el = editableRef.current;
+    return (el?.innerText || el?.textContent || '').trim();
+  };
+
+  const handleInput = () => {
+    const text = getDraftText();
+    hasEditedDraftRef.current = true;
+    setHasWritten(text.length > 0);
+    setDraftSaveError(false);
+  };
+
+  const saveDraftBeforeAuth = () => {
+    const text = getDraftText();
+
+    try {
+      if (!text) {
+        if (hasEditedDraftRef.current) {
+          localStorage.removeItem(DEMO_CONTENT_STORAGE_KEY);
+        }
+        setDraftSaveError(false);
+        return true;
+      }
+
+      localStorage.setItem(DEMO_CONTENT_STORAGE_KEY, text);
+      setDraftSaveError(false);
+      return true;
+    } catch (error) {
+      console.warn('Failed to save landing draft before signup:', error);
+      setDraftSaveError(true);
+      return false;
+    }
+  };
+
+  const handleContinue = () => {
+    if (saveDraftBeforeAuth()) {
+      onStartWriting();
+    }
+  };
+
+  const handleSignIn = () => {
+    if (saveDraftBeforeAuth()) {
+      onSignIn();
+    }
+  };
 
   const handleDemoClick = (event: MouseEvent<HTMLAnchorElement>) => {
     if (
@@ -42,118 +182,223 @@ export function LandingPage({
     ) {
       return;
     }
-
     event.preventDefault();
     onDemoClick();
   };
 
-  // Atmospheric gradient centered on manuscript area
-  const gradientPct = isDark ? 9 : 6;
-  const atmosphere = `radial-gradient(
-    ellipse 60% 70% at 62% 48%,
-    color-mix(in srgb, var(--color-accent) ${gradientPct}%, var(--color-bg-primary) ${100 - gradientPct}%) 0%,
-    var(--color-bg-primary) 60%
-  )`;
+  // Scroll-reveal for the gallery "second act".
+  useEffect(() => {
+    const root = landingRootRef.current;
+    if (!root) return;
+
+    const els = Array.from(root.querySelectorAll<HTMLElement>('.landing-reveal'));
+    if (!('IntersectionObserver' in window)) {
+      els.forEach((el) => el.classList.add('in'));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in');
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.18 }
+    );
+    els.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (focusTimeoutRef.current !== null) {
+        window.clearTimeout(focusTimeoutRef.current);
+      }
+      if (closeStartTimeoutRef.current !== null) {
+        window.clearTimeout(closeStartTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const hiddenHeroTabIndex = isWriting ? -1 : undefined;
 
   return (
-    <div className="landing-canvas" style={{ background: 'var(--color-bg-primary)' }}>
-      {/* Atmospheric radial gradient */}
-      <div className="landing-atmosphere" style={{ background: atmosphere }} />
+    <div ref={landingRootRef} className="landing-canvas">
+      <HeaderShell theme={theme} onThemeToggle={onThemeToggle} onSignIn={handleSignIn} />
 
-      {/* Shared header */}
-      <HeaderShell
-        theme={theme}
-        onThemeToggle={onThemeToggle}
-        onSignIn={onSignIn}
-      />
-
-      {/* Content wrapper — centers main + footer in remaining space */}
-      <div className="landing-content-wrap">
-      {/* Main composition — two-column desktop, single-column mobile */}
-      <main className="landing-main">
-        {/* Text column */}
-        <div className="landing-text-column">
-          <h1 className="landing-headline landing-entrance">
-            A quiet space for your thoughts.
-          </h1>
-
-          {/* CTA cluster */}
-          <div className="landing-cta-cluster landing-entrance landing-entrance-1">
-            <button type="button"
-              onClick={onStartWriting}
-              className="landing-cta-button focus-ring"
-              style={{ fontFamily: 'var(--font-body)' }}
+      {/* ─── Hero fold — quiet, and it becomes the editor ─── */}
+      <section className={`landing-hero${isWriting ? ' writing' : ''}`}>
+        <div className="landing-stack">
+          {/* Marketing prose */}
+          <div className="landing-prose" aria-hidden={isWriting}>
+            <h1 className="landing-headline">
+              Begin where you <em>are.</em>
+            </h1>
+            <p className="landing-sub">
+              A quiet space for the half-formed thought. No folders. No tags. Nothing to
+              learn — just room to think.
+            </p>
+            <button
+              type="button"
+              onClick={handleStartWriting}
+              className="landing-cta focus-ring"
+              tabIndex={hiddenHeroTabIndex}
             >
-              Start Writing
+              Start writing
             </button>
-
-            <p className="landing-proof-line">
-              Google, GitHub, or email. No credit card.
-            </p>
-
-            <p className="landing-encrypt-line">
-              End-to-end encrypted from the start.
-            </p>
-
+            <p className="landing-micro">No account needed to start.</p>
             <a
               href="/demo"
               onClick={handleDemoClick}
-              className="landing-demo-link"
-              style={{ fontFamily: 'var(--font-body)' }}
+              className="landing-demo-link focus-ring"
+              tabIndex={hiddenHeroTabIndex}
             >
               Explore the Practice Space
               <span className="landing-demo-arrow" aria-hidden="true">→</span>
             </a>
           </div>
 
-          {/* Proof rail — spec P0 #5: each claim links to verifiable proof */}
-          <div className="landing-proof-rail landing-entrance landing-entrance-2">
-            <a
-              href="https://github.com/anbuneel/yidhan"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="landing-proof-rail-link"
-            >
-              Open source
-            </a>
-            <span aria-hidden="true">·</span>
-            <span>Offline-first</span>
-            <span aria-hidden="true">·</span>
-            <span>End-to-end encrypted</span>
+          {/* The real writing surface, revealed in the hero's place (desktop) */}
+          <div className="landing-hero-editor-wrap" aria-hidden={!isWriting}>
+            <div className="landing-hero-editor">
+              <div className="landing-hero-glow" aria-hidden="true" />
+              <div
+                ref={editableRef}
+                className="landing-hero-doc"
+                contentEditable={isWriting}
+                suppressContentEditableWarning
+                role="textbox"
+                aria-multiline="true"
+                aria-label="Your writing"
+                spellCheck={isWriting}
+                onInput={handleInput}
+              />
+              <div className="landing-hero-foot">
+                <span className={`landing-seal${hasWritten ? ' show' : ''}`}>
+                  <span className="landing-seal-dot" aria-hidden="true" />
+                  Locked before it leaves your hands.
+                </span>
+                <button
+                  type="button"
+                  onClick={handleContinue}
+                  className={`landing-continue focus-ring${hasWritten ? ' show' : ''}`}
+                  disabled={!hasWritten}
+                  aria-hidden={!hasWritten}
+                  tabIndex={hasWritten ? 0 : -1}
+                >
+                  Continue in Yidhan →
+                </button>
+              </div>
+              {draftSaveError && (
+                <p className="landing-draft-error" role="alert">
+                  This browser blocked local saving. Copy your words before continuing.
+                </p>
+              )}
+            </div>
           </div>
         </div>
 
-        {/* Manuscript — matches real editor surface */}
-        <div
-          className="landing-manuscript landing-entrance-manuscript"
-          style={{
-            background: 'var(--color-bg-primary)',
-            padding: '3.8rem 4.18rem',
-            boxShadow: 'var(--shadow-manuscript)',
-          }}
+        <a
+          className="landing-scrollcue focus-ring"
+          href="#landing-surface"
+          aria-hidden={isWriting}
+          tabIndex={hiddenHeroTabIndex}
         >
-          <div className="landing-manuscript-glow" />
-          <div className="landing-manuscript-content">
-            <p className="landing-text-reveal" style={{ marginBottom: '1.2em', animationDelay: '0.4s' }}>
-              The light through the kitchen window this morning reminded me of
-              something I&apos;d forgotten: how good it feels to write without
-              worrying where the words will end up.
-            </p>
-            <p className="landing-text-reveal" style={{ marginBottom: '1.2em', animationDelay: '0.7s' }}>
-              No folders to choose, no tags to assign. Just a quiet surface
-              and the freedom to think out loud.
-            </p>
-            <p className="landing-text-reveal" style={{ marginBottom: 0, animationDelay: '1.0s' }}>
-              I used to keep a notebook by the bed. This feels like that,
-              but the pages never
-            </p>
-            <span className="landing-cursor" style={{ animationDelay: '1.3s, 1.7s' }}>▎</span>
-          </div>
-        </div>
-      </main>
+          <span>Or see how it feels</span>
+          <span className="landing-scrollcue-arrow" aria-hidden="true">↓</span>
+        </a>
+      </section>
 
-      {/* Footer nav */}
-      <nav className="landing-footer landing-entrance landing-entrance-3">
+      {/* ─── Gallery — the honest "second act": the real product ─── */}
+      <div className="landing-gallery">
+        {/* The surface */}
+        <section className="landing-piece landing-reveal" id="landing-surface">
+          <div className="landing-caption">
+            <p className="landing-kicker">The surface</p>
+            <h2 className="landing-piece-title">A page that gets out of the way.</h2>
+            <p className="landing-piece-body">
+              No sidebars. No menus crowding the margins. Write in focus mode and the
+              interface recedes — leaving only your words and a soft manuscript glow around
+              the page.
+            </p>
+          </div>
+          <div className="landing-mock-editor" aria-hidden="true">
+            <div className="landing-mock-glow" />
+            <div className="landing-mock-doc">
+              <div className="landing-mock-title">Four Thousand Weeks</div>
+              <p>
+                Started it last night. The bit about how we&rsquo;ll never &ldquo;get on
+                top of everything&rdquo; was oddly freeing.<span className="landing-car" />
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* What accumulates */}
+        <section className="landing-piece flip landing-reveal">
+          <div className="landing-caption">
+            <p className="landing-kicker">What accumulates</p>
+            <h2 className="landing-piece-title">Your thoughts, gathered like pages.</h2>
+            <p className="landing-piece-body">
+              Notes settle into a quiet, asymmetric arrangement — no rigid grid, no pressure
+              to organize. Tag them, or don&rsquo;t. They wait for you, exactly as you left
+              them.
+            </p>
+          </div>
+          <div className="landing-grid" aria-hidden="true">
+            {previewNotes.map((note) => (
+              <div key={note.id} className="landing-note-card-wrap">
+                <NoteCard
+                  note={note}
+                  onClick={() => undefined}
+                  onDelete={() => undefined}
+                  onTogglePin={() => undefined}
+                  isDecorative
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* What stays yours */}
+        <section className="landing-piece landing-reveal">
+          <div className="landing-caption">
+            <p className="landing-kicker">What stays yours</p>
+            <h2 className="landing-piece-title">Locked before it leaves your hands.</h2>
+            <p className="landing-piece-body">
+              Every word is encrypted on your device before it syncs — so it reaches your
+              other screens, but never ours readable. It works offline, and the code is open
+              for anyone to check.
+            </p>
+          </div>
+          <div className="landing-vault" aria-hidden="true">
+            <span className="landing-vault-ring" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+              <rect x="5" y="11" width="14" height="9" rx="2.2" />
+              <path d="M8 11V8a4 4 0 0 1 8 0v3" />
+              <circle cx="12" cy="15.5" r="1.4" fill="currentColor" stroke="none" />
+            </svg>
+          </div>
+        </section>
+      </div>
+
+      {/* ─── Close — echoes the hero ─── */}
+      <section className="landing-close landing-reveal">
+        <h2 className="landing-close-title">
+          Your page is <em>waiting.</em>
+        </h2>
+        <button type="button" onClick={handleCloseStart} className="landing-cta focus-ring">
+          Start writing
+        </button>
+        <p className="landing-micro">
+          No account needed — your first words stay on this device.
+        </p>
+      </section>
+
+      {/* ─── Footer nav ─── */}
+      <nav className="landing-footer">
         <button type="button" onClick={onChangelogClick} className="landing-nav-link focus-ring">
           Changelog
         </button>
@@ -185,17 +430,12 @@ export function LandingPage({
         {isInstallable && !isInstalled && (
           <>
             <span aria-hidden="true">·</span>
-            <button type="button"
+            <button
+              type="button"
               onClick={triggerInstall}
               className="landing-nav-link focus-ring flex items-center gap-1.5"
             >
-              <svg
-                className="size-3.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
+              <svg className="size-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -208,310 +448,356 @@ export function LandingPage({
           </>
         )}
       </nav>
-      </div>{/* end landing-content-wrap */}
 
       <style>{`
-        /* ─── Canvas ─── */
         .landing-canvas {
+          position: relative;
           min-height: 100vh;
-          position: relative;
-          overflow: hidden;
+          min-height: 100dvh;
           display: flex;
           flex-direction: column;
-          /* Stacking context so z-index: -1 on atmosphere paints above the
-             canvas background but below the header/content above it. */
-          isolation: isolate;
-        }
-        .landing-atmosphere {
-          position: absolute;
-          inset: 0;
-          pointer-events: none;
-          z-index: -1;
+          background: var(--color-bg-primary);
+          overflow-x: hidden;
         }
 
-        /* ─── Content wrapper — centers main+footer below pinned header ─── */
-        .landing-content-wrap {
-          flex: 1;
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
+        /* ─── Hero ─── */
+        .landing-hero {
           position: relative;
-          z-index: 1;
-        }
-
-        /* ─── Main composition ─── */
-        .landing-main {
-          position: relative;
-          z-index: 1;
+          min-height: calc(100vh - 4.5rem);
+          min-height: calc(100dvh - 4.5rem);
           display: grid;
-          grid-template-columns: 40% 1fr;
-          gap: 5%;
-          max-width: 1220px;
-          margin: 0 auto;
-          padding: 2rem 1vw;
-          align-items: center;
-          width: 100%;
+          place-items: center;
+          text-align: center;
+          padding: 2rem clamp(1.4rem, 5vw, 3rem) 4rem;
+          background: radial-gradient(
+            ellipse 70% 60% at 50% 44%,
+            color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-primary) 93%) 0%,
+            var(--color-bg-primary) 62%
+          );
         }
-
-        /* ─── Text column ─── */
-        .landing-text-column {
-          display: flex;
-          flex-direction: column;
+        .landing-stack {
+          display: grid;
+          width: min(680px, 100%);
         }
+        .landing-stack > * { grid-area: 1 / 1; }
 
+        /* Marketing prose */
+        .landing-prose {
+          animation: landing-fade-up 0.7s var(--ease-out-quint, ease-out) backwards;
+          transition: opacity 0.7s ease, transform 0.7s cubic-bezier(0.22,1,0.36,1), filter 0.7s ease;
+        }
         .landing-headline {
           font-family: var(--font-display);
-          color: var(--color-text-primary);
-          letter-spacing: -0.02em;
           font-weight: 300;
-          line-height: 1.08;
-          font-size: clamp(2rem, 3.4vw, 4.5rem);
-          margin: 0 0 2.25rem;
+          font-size: 4.75rem;
+          line-height: 1.03;
+          letter-spacing: 0;
+          margin: 0 0 1.6rem;
           text-wrap: balance;
+          color: var(--color-text-primary);
         }
-
-        /* ─── CTA cluster ─── */
-        .landing-cta-cluster {
-          display: flex;
-          flex-direction: column;
-          gap: 1rem;
+        .landing-headline em { font-style: italic; color: var(--color-accent); font-weight: 400; }
+        .landing-sub {
+          font-family: var(--font-body);
+          font-weight: 300;
+          font-size: 1.1rem;
+          line-height: 1.7;
+          color: var(--color-text-secondary);
+          max-width: 40ch;
+          margin: 0 auto 2.4rem;
         }
-
-        .landing-cta-button {
+        .landing-cta {
+          font-family: var(--font-body);
+          font-size: 1rem;
+          font-weight: 500;
           background: var(--color-cta-bg);
           color: var(--color-cta-text);
-          padding: 0.9rem 2.5rem;
-          border-radius: 8px;
-          font-size: 1.05rem;
-          font-weight: 500;
           border: none;
+          border-radius: 2px 16px 4px 16px;
+          padding: 0.9rem 2.4rem;
           cursor: pointer;
-          width: fit-content;
-          box-shadow: 0 4px 20px var(--color-accent-glow);
-          transition: all 0.3s ease;
+          box-shadow: 0 6px 24px var(--color-accent-glow);
+          transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
         }
-        .landing-cta-button:hover {
+        .landing-cta:hover {
+          transform: translateY(-1px);
           background: var(--color-cta-bg-hover);
-          box-shadow: 0 8px 30px var(--color-accent-glow);
+          box-shadow: 0 10px 34px var(--color-accent-glow);
         }
-
-        .landing-proof-line {
+        .landing-micro {
+          margin: 1.1rem 0 0;
           font-family: var(--font-body);
+          font-size: 0.76rem;
           color: var(--color-text-tertiary);
-          font-size: 0.8rem;
-          margin: 0;
         }
-
-        .landing-encrypt-line {
-          font-family: var(--font-body);
-          color: var(--color-accent);
-          font-size: 0.8rem;
-          margin: 0;
-          opacity: 0.85;
-          letter-spacing: 0.03em;
-        }
-
         .landing-demo-link {
-          font-size: 0.8rem;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.3rem;
+          margin-top: 1.6rem;
+          font-family: var(--font-body);
+          font-size: 0.82rem;
           color: var(--color-text-tertiary);
           text-decoration: none;
           border-bottom: 1px dotted var(--color-text-tertiary);
-          width: fit-content;
-          display: inline-flex;
-          align-items: center;
-          gap: 0.25rem;
           transition: color 0.2s ease, border-bottom-color 0.2s ease;
         }
-        .landing-demo-link:hover {
-          color: var(--color-accent);
-          border-bottom-color: var(--color-accent);
-        }
-        .landing-demo-arrow {
-          display: inline-block;
-          transition: transform 0.2s ease;
-        }
-        .landing-demo-link:hover .landing-demo-arrow {
-          transform: translateX(4px);
-        }
+        .landing-demo-link:hover { color: var(--color-accent); border-bottom-color: var(--color-accent); }
+        .landing-demo-arrow { display: inline-block; transition: transform 0.2s ease; }
+        .landing-demo-link:hover .landing-demo-arrow { transform: translateX(4px); }
 
-        /* ─── Proof rail ─── */
-        .landing-proof-rail {
-          display: flex;
-          gap: 0.6rem;
-          margin-top: 2.5rem;
-          font-family: var(--font-body);
-          font-size: 0.65rem;
-          text-transform: uppercase;
-          letter-spacing: 0.12em;
-          color: var(--color-text-tertiary);
-        }
-        .landing-proof-rail-link {
-          color: inherit;
-          text-decoration: none;
-        }
-        .landing-proof-rail-link:hover {
-          color: var(--color-accent);
-        }
-
-        /* ─── Manuscript ─── */
-        .landing-manuscript {
-          position: relative;
-          border-radius: var(--radius-card);
-          overflow: hidden;
-          border: 1px solid rgba(0, 0, 0, 0.06);
-        }
-        [data-theme="dark"] .landing-manuscript {
-          border: 1px solid rgba(255, 255, 255, 0.05);
-        }
-
-        .landing-manuscript-glow {
-          position: absolute;
-          inset: 0;
+        /* Hero editor (revealed) — matches the real manuscript surface */
+        .landing-hero-editor-wrap {
+          opacity: 0;
+          transform: translateY(10px);
           pointer-events: none;
-          background: radial-gradient(
-            ellipse 80% 50% at 50% 40%,
-            rgba(194, 86, 52, 0.12) 0%,
-            transparent 70%
-          );
+          transition: opacity 0.8s ease 0.12s, transform 0.8s cubic-bezier(0.22,1,0.36,1) 0.12s;
         }
-        [data-theme="dark"] .landing-manuscript-glow {
-          background: radial-gradient(
-            ellipse 80% 50% at 50% 50%,
-            rgba(212, 175, 55, 0.12) 0%,
-            transparent 70%
-          );
+        .landing-hero-editor {
+          position: relative;
+          text-align: left;
+          background: var(--color-bg-primary);
+          border: 1px solid var(--glass-border);
+          border-radius: var(--radius-card);
+          box-shadow: var(--shadow-manuscript);
+          padding: clamp(2.2rem, 4.5vw, 3.4rem) clamp(1.8rem, 4.5vw, 3.8rem);
+          min-height: 300px;
+          overflow: hidden;
+          transition: border-color 0.25s ease, box-shadow 0.25s ease;
         }
-
-        .landing-manuscript-content {
+        .landing-hero-editor:focus-within {
+          border-color: var(--color-accent-muted);
+          box-shadow:
+            var(--shadow-manuscript),
+            0 0 0 2px color-mix(in srgb, var(--color-accent) 26%, transparent);
+        }
+        .landing-hero-glow {
+          position: absolute; inset: 0; pointer-events: none;
+          background: radial-gradient(ellipse 80% 50% at 50% 36%, var(--color-accent-glow) 0%, transparent 70%);
+        }
+        .landing-hero-doc {
+          position: relative; z-index: 1;
+          font-family: var(--font-body);
+          font-weight: 400;
+          font-size: 1.2rem;
+          line-height: 1.75;
+          color: var(--color-text-primary);
+          outline: none;
+          caret-color: var(--color-accent);
+          min-height: 5.5em;
+          white-space: pre-wrap;
+          overflow-wrap: anywhere;
+          word-break: break-word;
+        }
+        .landing-hero-doc:empty::before {
+          content: "Begin where you are\\2026";
+          color: var(--color-text-tertiary);
+          font-style: italic;
+          font-weight: 300;
+          pointer-events: none;
+        }
+        .landing-hero-foot {
+          position: relative; z-index: 1;
+          display: flex; align-items: center; justify-content: space-between;
+          gap: 1rem; margin-top: 1.6rem;
+        }
+        .landing-seal {
+          font-family: var(--font-body);
+          font-size: 0.72rem; letter-spacing: 0.04em;
+          color: var(--color-text-tertiary);
+          display: inline-flex; align-items: center; gap: 0.5rem;
+          opacity: 0; transform: translateY(4px);
+          transition: opacity 0.6s ease, transform 0.6s ease;
+        }
+        .landing-seal-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); }
+        .landing-seal.show { opacity: 0.9; transform: none; }
+        .landing-continue {
+          font-family: var(--font-body);
+          font-size: 0.8rem;
+          color: var(--color-text-secondary);
+          background: none;
+          border: 1px solid var(--glass-border);
+          border-radius: 2px 12px 4px 12px;
+          padding: 0.45rem 1rem;
+          cursor: pointer;
+          opacity: 0; transform: translateY(4px);
+          pointer-events: none;
+          transition: opacity 0.6s ease, transform 0.6s ease, color 0.25s ease, border-color 0.25s ease;
+        }
+        .landing-continue.show { opacity: 1; transform: none; pointer-events: auto; }
+        .landing-continue:hover { color: var(--color-accent); border-color: var(--color-accent); }
+        .landing-draft-error {
           position: relative;
           z-index: 1;
+          margin: 1rem 0 0;
           font-family: var(--font-body);
-          color: var(--color-text-primary);
-          font-size: 1.2rem;
-          font-weight: 400;
-          line-height: 1.75;
+          font-size: 0.78rem;
+          line-height: 1.5;
+          color: var(--color-destructive);
         }
 
-        /* ─── Horizontal text reveal (P2 #12) — clip-path, GPU-composited ─── */
-        .landing-text-reveal {
-          clip-path: inset(0 100% 0 0);
-          animation: landing-text-reveal 0.8s ease-out forwards;
-          will-change: clip-path;
+        /* writing state cross-fade */
+        .landing-hero.writing .landing-prose { opacity: 0; transform: translateY(-8px); filter: blur(2px); pointer-events: none; }
+        .landing-hero.writing .landing-hero-editor-wrap { opacity: 1; transform: none; pointer-events: auto; }
+        .landing-hero.writing .landing-scrollcue { opacity: 0; pointer-events: none; }
+
+        .landing-scrollcue {
+          position: absolute; left: 50%; bottom: 2.2rem; transform: translateX(-50%);
+          display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+          font-family: var(--font-body);
+          font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.18em;
+          color: var(--color-text-tertiary); text-decoration: none;
+          animation: landing-float 3.4s ease-in-out infinite;
+          transition: opacity 0.5s ease;
         }
-        @keyframes landing-text-reveal {
-          from { clip-path: inset(0 100% 0 0); }
-          to { clip-path: inset(0 0% 0 0); }
+        .landing-scrollcue:hover { color: var(--color-accent); }
+        .landing-scrollcue-arrow { font-size: 1rem; }
+
+        /* ─── Gallery ─── */
+        .landing-gallery {
+          width: 100%;
+          max-width: 1080px;
+          margin: 0 auto;
+          padding: clamp(3rem, 10vw, 9rem) clamp(1.4rem, 6vw, 4rem);
+        }
+        .landing-piece {
+          display: grid;
+          gap: clamp(2rem, 5vw, 4.5rem);
+          align-items: center;
+          margin-bottom: clamp(6rem, 16vw, 13rem);
+        }
+        .landing-piece:last-child { margin-bottom: 0; }
+        @media (min-width: 860px) {
+          .landing-piece { grid-template-columns: 1fr 1fr; }
+          .landing-piece.flip .landing-caption { order: 2; }
+        }
+        .landing-kicker {
+          font-family: var(--font-body);
+          font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.18em;
+          color: var(--color-accent); margin: 0 0 1rem;
+        }
+        .landing-piece-title {
+          font-family: var(--font-display); font-weight: 300;
+          font-size: 2.65rem; line-height: 1.1; letter-spacing: 0;
+          margin: 0 0 1rem; color: var(--color-text-primary);
+        }
+        .landing-piece-body {
+          font-family: var(--font-body);
+          font-size: 1.02rem; line-height: 1.75;
+          color: var(--color-text-secondary); max-width: 42ch; margin: 0;
         }
 
-        /* ─── Breathing cursor — appears after text reveal ─── */
-        .landing-cursor {
-          color: var(--color-accent);
-          font-size: 1.1rem;
-          opacity: 0;
-          animation: landing-cursor-appear 0.4s ease-out forwards, landing-cursor-breathe 3s ease-in-out 1.7s infinite;
+        /* Surface mock editor */
+        .landing-mock-editor {
+          position: relative;
+          background: var(--color-bg-primary);
+          border: 1px solid var(--glass-border);
+          border-radius: var(--radius-card);
+          box-shadow: var(--shadow-manuscript);
+          padding: clamp(2rem, 4vw, 3.2rem);
+          overflow: hidden;
         }
-        @keyframes landing-cursor-appear {
-          from { opacity: 0; }
-          to { opacity: 1; }
+        .landing-mock-glow {
+          position: absolute; inset: 0; pointer-events: none;
+          background: radial-gradient(ellipse 80% 50% at 50% 36%, var(--color-accent-glow) 0%, transparent 70%);
         }
-        @keyframes landing-cursor-breathe {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.3; }
+        .landing-mock-doc { position: relative; z-index: 1; }
+        .landing-mock-title {
+          font-family: var(--font-display); font-weight: 600;
+          font-size: 1.9rem; line-height: 1.3; letter-spacing: 0;
+          color: var(--color-text-primary); margin-bottom: 0.8rem;
         }
+        .landing-mock-doc p {
+          font-family: var(--font-body); font-weight: 400;
+          font-size: 1.16rem; line-height: 1.85;
+          color: var(--color-text-primary); margin: 0;
+        }
+
+        /* Note grid - rendered with the real NoteCard in decorative mode */
+        .landing-grid { columns: 2; column-gap: 1rem; }
+        @media (max-width: 520px) { .landing-grid { columns: 1; } }
+        .landing-note-card-wrap { break-inside: avoid; margin-bottom: 1rem; display: block; }
+        /* Vault */
+        .landing-vault {
+          position: relative; display: grid; place-items: center;
+          aspect-ratio: 1 / 1; max-width: 360px; width: 100%; margin: 0 auto;
+          border-radius: var(--radius-card);
+          background: radial-gradient(circle at 50% 42%, var(--color-accent-glow), transparent 60%), var(--color-bg-secondary);
+          border: 1px solid var(--glass-border);
+        }
+        .landing-vault svg { width: 38%; height: 38%; color: var(--color-accent); }
+        .landing-vault-ring {
+          position: absolute; inset: 14%; border-radius: 50%;
+          border: 1px dashed color-mix(in srgb, var(--color-accent) 40%, transparent);
+        }
+
+        /* ─── Close ─── */
+        .landing-close {
+          text-align: center;
+          padding: clamp(5rem, 14vw, 11rem) 1.4rem clamp(3rem, 8vw, 6rem);
+        }
+        .landing-close-title {
+          font-family: var(--font-display); font-weight: 300;
+          font-size: 3.4rem; line-height: 1.06;
+          margin: 0 0 2.2rem; color: var(--color-text-primary);
+        }
+        .landing-close-title em { font-style: italic; color: var(--color-accent); font-weight: 400; }
 
         /* ─── Footer ─── */
         .landing-footer {
-          position: relative;
-          z-index: 1;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 0.5rem;
-          padding: 1.5rem clamp(1rem, 4vw, 4rem);
-          font-family: var(--font-body);
-          font-size: 0.8rem;
+          display: flex; align-items: center; justify-content: center;
+          gap: 0.5rem; flex-wrap: wrap;
+          padding: 2.5rem clamp(1rem, 4vw, 4rem) 3rem;
+          margin-top: auto;
+          font-family: var(--font-body); font-size: 0.78rem;
           color: var(--color-text-tertiary);
-          flex-wrap: wrap;
         }
         .landing-nav-link {
-          color: inherit;
-          background: none;
-          border: none;
-          cursor: pointer;
-          font-family: inherit;
-          font-size: inherit;
-          padding: 0;
-          transition: color 0.2s ease;
+          color: inherit; background: none; border: none; cursor: pointer;
+          font-family: inherit; font-size: inherit; padding: 0;
+          transition: color 0.2s ease; text-decoration: none;
         }
-        .landing-nav-link:hover {
-          color: var(--color-accent);
+        .landing-nav-link:hover { color: var(--color-accent); }
+
+        /* ─── Reveal ─── */
+        .landing-reveal { opacity: 0; transform: translateY(26px); transition: opacity 0.9s ease, transform 0.9s cubic-bezier(0.22,1,0.36,1); }
+        .landing-reveal.in { opacity: 1; transform: none; }
+
+        .landing-car {
+          display: inline-block; width: 2px; height: 1.05em; vertical-align: -0.16em;
+          margin-left: 0.1em; border-radius: 1px; background: var(--color-accent);
+          animation: landing-blink 2.6s ease-in-out infinite;
         }
 
-        /* ─── Entrance animations ─── */
-        .landing-entrance {
-          will-change: opacity, transform;
-          animation: landing-fade-up 0.6s ease-out backwards;
-        }
-        .landing-entrance-1 { animation-delay: 0.08s; }
-        .landing-entrance-2 { animation-delay: 0.16s; }
-        .landing-entrance-3 { animation-delay: 0.24s; }
-        /* Manuscript is heavier — slower entrance, larger travel */
-        .landing-entrance-manuscript {
-          animation: landing-fade-up-heavy 0.9s ease-out backwards;
-          animation-delay: 0.15s;
-        }
+        @keyframes landing-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.2; } }
+        @keyframes landing-float { 0%, 100% { transform: translate(-50%, 0); } 50% { transform: translate(-50%, 6px); } }
+        @keyframes landing-fade-up { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
 
-        @keyframes landing-fade-up {
-          from { opacity: 0; transform: translateY(12px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes landing-fade-up-heavy {
-          from { opacity: 0; transform: translateY(24px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-
-        /* ─── Mobile: stack to single column ─── */
         @media (max-width: 768px) {
-          .landing-main {
-            grid-template-columns: 1fr;
-            gap: 2rem;
-            padding: 0 1.5rem;
-            align-items: start;
-          }
-
-          .landing-text-column {
-            padding: 1rem 0 0;
-            text-align: center;
-            align-items: center;
-          }
-
-          .landing-canvas .landing-headline {
-            font-size: clamp(2rem, 8vw, 3rem);
-            margin-bottom: 1.5rem;
-          }
-
-          .landing-cta-cluster {
-            align-items: center;
-          }
-
-          .landing-proof-rail {
-            justify-content: center;
-            flex-wrap: wrap;
-          }
-
-          .landing-manuscript {
-            margin-bottom: 1rem;
-            padding: 2rem 1.5rem !important;
-          }
+          .landing-hero { min-height: calc(100vh - 4.5rem); }
+          .landing-hero { min-height: calc(100svh - 4.5rem); }
+          .landing-scrollcue { display: none; }
+          .landing-headline { font-size: 3.2rem; }
+          .landing-sub { font-size: 1rem; }
+          .landing-piece-title { font-size: 2.2rem; }
+          .landing-close-title { font-size: 2.6rem; }
         }
 
-        /* ─── Reduced motion — stillness ─── */
+        @media (max-width: 420px) {
+          .landing-headline { font-size: 2.75rem; }
+          .landing-piece-title { font-size: 2rem; }
+          .landing-close-title { font-size: 2.3rem; }
+        }
+
         @media (prefers-reduced-motion: reduce) {
-          .landing-entrance,
-          .landing-entrance-manuscript { animation: none; }
-          .landing-text-reveal { animation: none; clip-path: none; }
-          .landing-cursor { animation: none; opacity: 1; }
-          .landing-cta-button { transition: none; }
+          .landing-prose,
+          .landing-hero-editor-wrap,
+          .landing-scrollcue,
+          .landing-seal,
+          .landing-continue,
+          .landing-car,
+          .landing-reveal { animation: none !important; transition: none !important; }
+          .landing-reveal { opacity: 1; transform: none; }
         }
       `}</style>
     </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -337,28 +337,30 @@ export function LandingPage({
         </section>
 
         {/* What accumulates */}
-        <section className="landing-piece flip landing-reveal">
-          <div className="landing-caption">
-            <p className="landing-kicker">What accumulates</p>
-            <h2 className="landing-piece-title">Your thoughts, gathered like pages.</h2>
-            <p className="landing-piece-body">
-              Notes settle into a quiet, asymmetric arrangement — no rigid grid, no pressure
-              to organize. Tag them, or don&rsquo;t. They wait for you, exactly as you left
-              them.
-            </p>
-          </div>
-          <div className="landing-grid" aria-hidden="true">
-            {previewNotes.map((note) => (
-              <div key={note.id} className="landing-note-card-wrap">
-                <NoteCard
-                  note={note}
-                  onClick={() => undefined}
-                  onDelete={() => undefined}
-                  onTogglePin={() => undefined}
-                  isDecorative
-                />
-              </div>
-            ))}
+        <section className="landing-piece-wide">
+          <div className="landing-wide-inner landing-reveal">
+            <div className="landing-caption">
+              <p className="landing-kicker">What accumulates</p>
+              <h2 className="landing-piece-title">Your thoughts, gathered like pages.</h2>
+              <p className="landing-piece-body">
+                Notes settle into a quiet, asymmetric arrangement — no rigid grid, no pressure
+                to organize. Tag them, or don&rsquo;t. They wait for you, exactly as you left
+                them.
+              </p>
+            </div>
+            <div className="landing-grid" aria-hidden="true">
+              {previewNotes.map((note) => (
+                <div key={note.id} className="landing-note-card-wrap">
+                  <NoteCard
+                    note={note}
+                    onClick={() => undefined}
+                    onDelete={() => undefined}
+                    onTogglePin={() => undefined}
+                    isDecorative
+                  />
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 
@@ -714,9 +716,25 @@ export function LandingPage({
         }
 
         /* Note grid - rendered with the real NoteCard in decorative mode */
-        .landing-grid { columns: 2; column-gap: 1rem; }
-        @media (max-width: 520px) { .landing-grid { columns: 1; } }
-        .landing-note-card-wrap { break-inside: avoid; margin-bottom: 1rem; display: block; }
+        /* "What accumulates" steps out of the editorial 2-col split: a centered
+           caption above a centered 2-up masonry. Cards render at app-true width
+           (~410px, same as the real library) and the staggered heights give the
+           "asymmetric, no rigid grid" arrangement the copy promises. */
+        .landing-piece-wide { margin-bottom: clamp(6rem, 16vw, 13rem); }
+        .landing-piece-wide .landing-caption {
+          text-align: center;
+          max-width: 48ch;
+          margin: 0 auto clamp(2.5rem, 5vw, 3.5rem);
+        }
+        .landing-piece-wide .landing-piece-body { margin-left: auto; margin-right: auto; }
+        .landing-grid {
+          columns: 2;
+          column-gap: 1.5rem;
+          max-width: 846px;
+          margin: 0 auto;
+        }
+        @media (max-width: 700px) { .landing-grid { columns: 1; max-width: 420px; } }
+        .landing-note-card-wrap { break-inside: avoid; margin-bottom: 1.5rem; display: block; }
         /* Vault */
         .landing-vault {
           position: relative; display: grid; place-items: center;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -237,8 +237,8 @@ export function LandingPage({
               Begin where you <em>are.</em>
             </h1>
             <p className="landing-sub">
-              A quiet space for the half-formed thought. No folders. No tags. Nothing to
-              learn — just room to think.
+              A quiet space for the half-formed thought. No folders. No organizing.
+              Nothing to learn — just room to think.
             </p>
             <button
               type="button"

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -113,6 +113,7 @@ export const NoteCard = memo(function NoteCard({
         }
       }}
       onMouseLeave={(e) => {
+        if (isDecorative) return;
         e.currentTarget.style.boxShadow = isCompact ? 'var(--shadow-sm)' : 'var(--shadow-md)';
       }}
     >

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -10,10 +10,19 @@ interface NoteCardProps {
   onDelete: (id: string) => void;
   onTogglePin: (id: string, pinned: boolean) => void;
   isCompact?: boolean;
+  isDecorative?: boolean;
   searchQuery?: string;
 }
 
-export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogglePin, isCompact = false, searchQuery }: NoteCardProps) {
+export const NoteCard = memo(function NoteCard({
+  note,
+  onClick,
+  onDelete,
+  onTogglePin,
+  isCompact = false,
+  isDecorative = false,
+  searchQuery
+}: NoteCardProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -79,14 +88,13 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         note-card
         relative
         overflow-hidden
-        cursor-pointer
         flex flex-col
         transition-all duration-300
         focus:outline-none
         focus:ring-2
         focus:ring-[var(--color-accent)]
         focus:ring-offset-2
-        active:scale-[0.98]
+        ${isDecorative ? '' : 'cursor-pointer active:scale-[0.98]'}
         ${isDeleting ? 'deleting' : ''}
         ${isCompact ? 'note-card-compact p-3' : 'p-6 pb-5'}
       `}
@@ -100,7 +108,7 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         maxHeight: isCompact ? '120px' : '300px',
       }}
       onMouseEnter={(e) => {
-        if (!isCompact) {
+        if (!isCompact && !isDecorative) {
           e.currentTarget.style.boxShadow = 'var(--shadow-lg)';
         }
       }}
@@ -108,15 +116,17 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         e.currentTarget.style.boxShadow = isCompact ? 'var(--shadow-sm)' : 'var(--shadow-md)';
       }}
     >
-      <button
-        type="button"
-        className="absolute inset-0 z-10 h-full w-full rounded-[inherit] border-0 bg-transparent p-0 focus-ring"
-        aria-label={`Open note: ${note.title || 'Untitled'}`}
-        onClick={() => onClick(note.id)}
-      />
+      {!isDecorative && (
+        <button
+          type="button"
+          className="absolute inset-0 z-10 h-full w-full rounded-[inherit] border-0 bg-transparent p-0 focus-ring"
+          aria-label={`Open note: ${note.title || 'Untitled'}`}
+          onClick={() => onClick(note.id)}
+        />
+      )}
 
       {/* Pin button - top-right corner (only in full mode) */}
-      {!isCompact && (
+      {!isCompact && !isDecorative && (
         <button type="button"
           onClick={handlePinClick}
           className={`
@@ -143,6 +153,17 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
           </svg>
         </button>
+      )}
+      {!isCompact && isDecorative && note.pinned && (
+        <span
+          className="absolute top-4 right-4 z-20 flex size-6 items-center justify-center"
+          style={{ color: 'var(--color-accent-muted)' }}
+          aria-hidden="true"
+        >
+          <svg className="size-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+          </svg>
+        </span>
       )}
 
       {/* Title row - with inline pin in compact mode */}
@@ -239,7 +260,7 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
         </time>
 
         {/* Delete button - hidden in compact mode (use swipe instead) */}
-        {!isCompact && (
+        {!isCompact && !isDecorative && (
           <button type="button"
             onClick={handleDeleteClick}
             className="
@@ -275,4 +296,9 @@ export const NoteCard = memo(function NoteCard({ note, onClick, onDelete, onTogg
 
     </div>
   );
-}, (prev, next) => prev.note === next.note && prev.isCompact === next.isCompact && prev.searchQuery === next.searchQuery);
+}, (prev, next) =>
+  prev.note === next.note &&
+  prev.isCompact === next.isCompact &&
+  prev.isDecorative === next.isDecorative &&
+  prev.searchQuery === next.searchQuery
+);

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,6 +8,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.19.0',
+    date: '2026-06-07',
+    changes: [
+      { type: 'feature', text: 'Landing page reimagined as a quiet hero that becomes a lightweight writing surface on desktop, with first drafts carried into signup' },
+      { type: 'improvement', text: 'Landing page now follows the hero with a real-product gallery showing the writing surface, Practice Space starter notes, and encryption/offline/open-source promise' },
+      { type: 'improvement', text: 'Mobile landing CTA now opens the Practice Space directly to avoid soft-keyboard viewport jumps during the hero reveal' },
+    ],
+  },
+  {
     version: '3.18.1',
     date: '2026-06-01',
     changes: [

--- a/src/services/demoStorage.ts
+++ b/src/services/demoStorage.ts
@@ -48,6 +48,7 @@ export interface DemoState {
 // ============================================================================
 
 export const DEMO_STORAGE_KEY = 'yidhan-demo-state';
+export const DEMO_CONTENT_STORAGE_KEY = 'yidhan-demo-content';
 export const DEMO_STORAGE_VERSION = 1;
 
 const STARTER_NOTES: DemoNote[] = [
@@ -129,6 +130,10 @@ function createDefaultState(): DemoState {
       ribbonDismissedAt: null,
     },
   };
+}
+
+export function createDemoStarterPreviewState(): DemoState {
+  return createDefaultState();
 }
 
 // ============================================================================

--- a/src/services/demoStorage.ts
+++ b/src/services/demoStorage.ts
@@ -73,7 +73,7 @@ const STARTER_NOTES: DemoNote[] = [
 </ul>
 <p>Started Four Thousand Weeks last night. The bit about how we'll never "get on top of everything" was oddly freeing.</p>`,
     pinned: false,
-    tagIds: [],
+    tagIds: ['tag-ideas'],
     createdAt: Date.now(),
     updatedAt: Date.now(),
   },
@@ -96,7 +96,7 @@ const STARTER_NOTES: DemoNote[] = [
 <li>Try that new coffee place on 5th</li>
 </ul>`,
     pinned: false,
-    tagIds: [],
+    tagIds: ['tag-journal'],
     createdAt: Date.now(),
     updatedAt: Date.now(),
   },


### PR DESCRIPTION
## Summary
- Reimagines the landing page as a quiet hero that becomes a lightweight writing surface on desktop.
- Carries first-draft text into signup using the shared demo-content storage key and migrates it into an encrypted first note after unlock.
- Routes mobile Start writing to the Practice Space, and renders the gallery from shared Practice Space starter data using decorative NoteCard previews.
- Updates changelog, README, PRD, UI layout docs, CLAUDE.md, and synced AGENTS.md.

## Review fixes
- Prevents focus from remaining inside hidden hero prose during the desktop reveal.
- Keeps header Sign In from saving a typed hero draft into an existing-account migration path.
- Removes hidden gallery/card controls and hidden hero controls from the tab order.
- Adds reduced-motion coverage for post-typing reveal elements and wraps long unbroken draft text.
- Shows gallery notes at app-true size on wide desktop, adds sample tags to shared Practice Space starter data, and replaces the inaccurate "No tags" hero copy.
- Updates the stale landing E2E spec to match the new hero/mobile flow.
- Pins `npm run doctor` to `react-doctor@0.4.2 --no-telemetry` for reproducible local scans.

## Verification
- `npm run check`
- `npx -y react-doctor@0.4.2 --no-telemetry --verbose --diff` (1 warning left: `role="textbox"` on the intentional `contentEditable` writing surface; latest Claude review agrees this role is appropriate.)
- `npm run e2e -- e2e/auth.spec.ts --project=chromium -g "shows landing page|starts writing" --workers=1 --reporter=list` (the two focused landing tests passed; Playwright then hung during Windows dev-server teardown.)
- GitHub CI passed on latest head `e1be891`.
- Claude Code Review passed on latest head `e1be891`; latest comments are non-blocking.
- Vercel preview is ready on latest head `e1be891`.
- `expect-cli --version` returns `0.0.12`; the Claude-agent Expect run started but timed out before verdict, and the Codex-agent run requires `codex login`, so browser assertions were verified with Playwright directly.