### PR TITLE
feat: add server-owned account deletion workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 ### Soft-delete, sharing, and demo mode
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
-- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false`. The server-owned workflow exists in repo, but re-enablement stays blocked until production verification and a throwaway-account deletion drill pass.
+- Account offboarding ("Letting Go") is enabled via `ACCOUNT_OFFBOARDING_ENABLED = true` after production verification, a scheduler smoke test, and a throwaway-account deletion drill passed. The server-owned workflow creates a 14-day deletion request, supports cancellation during the grace period, and deletes app data plus the Supabase Auth user through the service-role worker.
 - Legacy plaintext repair tooling was removed after the pre-launch repair and `launch_security_hardening.sql` verification. Do not reintroduce plaintext-note compatibility for launch builds.
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
 - Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
@@ -370,7 +370,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. Do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
+- **Account offboarding:** Self-serve "Letting Go" is enabled after production verification, a scheduler smoke test, and a throwaway-account deletion drill passed. Email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. The scheduled service-role worker processes due requests, re-checks cancellation state, deletes app data, deletes the Supabase Auth user, and writes the audit trail.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 ### Soft-delete, sharing, and demo mode
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
-- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false` until a server-owned deletion workflow exists
+- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false`. The server-owned workflow exists in repo, but re-enablement stays blocked until production verification and a throwaway-account deletion drill pass.
 - Legacy plaintext repair tooling was removed after the pre-launch repair and `launch_security_hardening.sql` verification. Do not reintroduce plaintext-note compatibility for launch builds.
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
 - Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
@@ -302,7 +302,7 @@ content...
 - Google/GitHub OAuth use Supabase's `signInWithOAuth` with redirect back to app origin
 - OAuth-first layout: OAuth buttons appear FIRST, then "or continue with email" divider, then email form
 - Production OAuth requires Supabase Site URL and Redirect URLs to match deployment domain
-- Extensive code splitting: Editor lazy-loaded (415KB chunk), views/modals in separate chunks, initial bundle 332KB (-44% from 596KB)
+- Current production build sizing (2026-06-21): main bundle 778.61KB (240.48KB gzip), Editor lazy chunk 443.26KB (133.96KB gzip), views/modals in separate chunks. Treat the main-bundle regression as a performance follow-up, not a launch security blocker.
 - Auth component supports modal mode (`isModal` prop) for landing page overlay
 
 ## Deployment
@@ -369,7 +369,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. Do not promise account deletion until a backend/service-role deletion workflow exists.
+- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).
@@ -435,3 +435,5 @@ SQL migrations are stored in `supabase/migrations/`:
 - `add_restore_timestamps_rpc.sql`
 - `fix_note_shares_rls_ownership.sql`
 - `update_notes_display_updated_at.sql`
+- `launch_security_hardening.sql`
+- `add_account_deletion_workflow.sql`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,7 @@ content...
 - User's full name is stored in Supabase `user_metadata.full_name`
 - Password recovery detected via Supabase `PASSWORD_RECOVERY` auth event
 - Google/GitHub OAuth use Supabase's `signInWithOAuth` with redirect back to app origin
+- Account deletion re-auth for Google/GitHub accounts uses a server-verified email OTP before minting the deletion confirmation token; typed-email confirmation is not valid proof.
 - OAuth-first layout: OAuth buttons appear FIRST, then "or continue with email" divider, then email form
 - Production OAuth requires Supabase Site URL and Redirect URLs to match deployment domain
 - Current production build sizing (2026-06-21): main bundle 778.61KB (240.48KB gzip), Editor lazy chunk 443.26KB (133.96KB gzip), views/modals in separate chunks. Treat the main-bundle regression as a performance follow-up, not a launch security blocker.
@@ -369,7 +370,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
+- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. Do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 ### Soft-delete, sharing, and demo mode
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
-- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false`. The server-owned workflow exists in repo, but re-enablement stays blocked until production verification and a throwaway-account deletion drill pass.
+- Account offboarding ("Letting Go") is enabled via `ACCOUNT_OFFBOARDING_ENABLED = true` after production verification, a scheduler smoke test, and a throwaway-account deletion drill passed. The server-owned workflow creates a 14-day deletion request, supports cancellation during the grace period, and deletes app data plus the Supabase Auth user through the service-role worker.
 - Legacy plaintext repair tooling was removed after the pre-launch repair and `launch_security_hardening.sql` verification. Do not reintroduce plaintext-note compatibility for launch builds.
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
 - Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
@@ -370,7 +370,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. Do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
+- **Account offboarding:** Self-serve "Letting Go" is enabled after production verification, a scheduler smoke test, and a throwaway-account deletion drill passed. Email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. The scheduled service-role worker processes due requests, re-checks cancellation state, deletes app data, deletes the Supabase Auth user, and writes the audit trail.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ Avoid: creating new inline `style={{}}` objects for static values that could be 
 ### Soft-delete, sharing, and demo mode
 - Soft-delete (Faded Notes) functions are in `src/services/notes.ts`
 - Share as Letter (E2EE) functions are in `src/services/notes.ts` — uses capability-link model with per-share keys
-- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false` until a server-owned deletion workflow exists
+- Account offboarding ("Letting Go") is hidden for public launch via `ACCOUNT_OFFBOARDING_ENABLED = false`. The server-owned workflow exists in repo, but re-enablement stays blocked until production verification and a throwaway-account deletion drill pass.
 - Legacy plaintext repair tooling was removed after the pre-launch repair and `launch_security_hardening.sql` verification. Do not reintroduce plaintext-note compatibility for launch builds.
 - Demo/Practice Space (`/demo`): `src/services/demoStorage.ts`, `src/hooks/useDemoState.ts`, `src/pages/DemoPage.tsx`
 - Landing hero drafts save to `DEMO_CONTENT_STORAGE_KEY` (`yidhan-demo-content`) before signup; `App.tsx` migrates them into an encrypted "My first note" after auth/unlock
@@ -302,7 +302,7 @@ content...
 - Google/GitHub OAuth use Supabase's `signInWithOAuth` with redirect back to app origin
 - OAuth-first layout: OAuth buttons appear FIRST, then "or continue with email" divider, then email form
 - Production OAuth requires Supabase Site URL and Redirect URLs to match deployment domain
-- Extensive code splitting: Editor lazy-loaded (415KB chunk), views/modals in separate chunks, initial bundle 332KB (-44% from 596KB)
+- Current production build sizing (2026-06-21): main bundle 778.61KB (240.48KB gzip), Editor lazy chunk 443.26KB (133.96KB gzip), views/modals in separate chunks. Treat the main-bundle regression as a performance follow-up, not a launch security blocker.
 - Auth component supports modal mode (`isModal` prop) for landing page overlay
 
 ## Deployment
@@ -369,7 +369,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. Do not promise account deletion until a backend/service-role deletion workflow exists.
+- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).
@@ -435,3 +435,5 @@ SQL migrations are stored in `supabase/migrations/`:
 - `add_restore_timestamps_rpc.sql`
 - `fix_note_shares_rls_ownership.sql`
 - `update_notes_display_updated_at.sql`
+- `launch_security_hardening.sql`
+- `add_account_deletion_workflow.sql`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ content...
 - User's full name is stored in Supabase `user_metadata.full_name`
 - Password recovery detected via Supabase `PASSWORD_RECOVERY` auth event
 - Google/GitHub OAuth use Supabase's `signInWithOAuth` with redirect back to app origin
+- Account deletion re-auth for Google/GitHub accounts uses a server-verified email OTP before minting the deletion confirmation token; typed-email confirmation is not valid proof.
 - OAuth-first layout: OAuth buttons appear FIRST, then "or continue with email" divider, then email form
 - Production OAuth requires Supabase Site URL and Redirect URLs to match deployment domain
 - Current production build sizing (2026-06-21): main bundle 778.61KB (240.48KB gzip), Editor lazy chunk 443.26KB (133.96KB gzip), views/modals in separate chunks. Treat the main-bundle regression as a performance follow-up, not a launch security blocker.
@@ -369,7 +370,7 @@ See `docs/plans/capacitor-implementation-plan.md` for detailed setup guide.
 - **Share as Letter:** E2EE-compatible sharing via capability links. Per-share random AES-256-GCM key in URL fragment (`#k=<base64url>`). Server stores only ciphertext via `fetch_shared_note` RPC. Max 30-day TTL, soft-delete revocation. URL format: `/s/<token>/<slug>#k=<key>`
 - **Database enforcement:** Public launch hardening requires server note rows to contain encrypted payload metadata and empty plaintext `title`/`content` columns. The launch migration intentionally fails if existing rows still violate that invariant.
 - **Legacy repair status:** Pre-launch plaintext rows were repaired or removed before hardening. If preflight ever reports unsafe rows again, treat that as a data incident; the launch app should fail closed rather than expose a repair UI.
-- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
+- **Account offboarding:** Self-serve "Letting Go" is disabled for public launch. The backend/service-role deletion workflow is implemented behind the disabled flag; email/password users verify by password and Google/GitHub users verify by server-checked email OTP before a deletion request can be created. Do not promise or re-enable account deletion until production verification and a throwaway-account deletion drill pass.
 
 ### Password Policy
 - Account passwords: minimum 8 characters (enforced in Auth.tsx and SettingsModal.tsx). E2EE passphrases: minimum 12 characters plus strength policy (enforced in PassphraseSetup.tsx and EncryptionContext.tsx).

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -23,9 +23,9 @@ Core product documentation.
 
 | Document | Description | Date |
 |----------|-------------|------|
-| [prd.md](prd.md) | Product Requirements Document (features, personas, user flows) | 2025-12-29 |
+| [prd.md](prd.md) | Product Requirements Document (features, personas, user flows, account deletion gate) | 2026-06-21 |
 | [roadmap.md](roadmap.md) | **NEW** Unified product roadmap (29 items across 4 phases, consolidated from 8+ docs) | 2026-03-03 |
-| [technical-spec.md](technical-spec.md) | Technical architecture and implementation details | 2025-12-29 |
+| [technical-spec.md](technical-spec.md) | Technical architecture, schema, and implementation details | 2026-06-21 |
 | [ui-layout.md](ui-layout.md) | ASCII diagrams of all UI components and layouts | 2025-12-29 |
 
 ---
@@ -39,7 +39,7 @@ Business strategy, competitive positioning, and launch planning.
 | [design-critique-tracker.md](active/design-critique-tracker.md) | Design critique findings tracker - decisions, completed items, open issues | 2026-03-07 |
 | [strategic-viability-review-claude.md](active/strategic-viability-review-claude.md) | Honest competitive viability assessment and gap analysis | 2026-01-06 |
 | [competitive-design-evaluation-claude.md](active/competitive-design-evaluation-claude.md) | Design comparison vs Notion, Bear, Apple Notes, Obsidian, Craft | 2025-12-26 |
-| [launch-readiness-assessment.md](active/launch-readiness-assessment.md) | Launch readiness checklist (93% ready as of 2025-12-28) | 2025-12-28 |
+| [launch-readiness-assessment.md](active/launch-readiness-assessment.md) | Launch readiness assessment with 2026-06-21 security hardening closeout and remaining non-blocking launch decisions | 2026-06-21 |
 | [monetization-philosophy.md](active/monetization-philosophy.md) | Pricing strategy aligned with wabi-sabi philosophy | 2025-12-26 |
 | [logo-and-branding.md](active/logo-and-branding.md) | Branding requirements, logo concepts, assets needed | 2025-12-26 |
 
@@ -118,7 +118,7 @@ Security reviews and analysis.
 | Document | Description | Date |
 |----------|-------------|------|
 | [code-review-b8a4c2e1.md](reviews/code-review-b8a4c2e1.md) | Launch security hardening multi-agent code review: E2EE invariants, SQL hardening, review findings, and dispositions | 2026-06-21 |
-| [security-launch-assessment-codex-2026-06-08.md](analysis/security-launch-assessment-codex-2026-06-08.md) | Public launch security assessment: E2EE validation, launch blockers, dependency scan, and hardening checklist | 2026-06-08 |
+| [security-launch-assessment-codex-2026-06-08.md](analysis/security-launch-assessment-codex-2026-06-08.md) | Public launch security assessment and 2026-06-21 closeout: E2EE validation, hardening, and Supabase verification status | 2026-06-21 |
 | [encryption-capability-analysis-claude.md](analysis/encryption-capability-analysis-claude.md) | E2EE encryption capability analysis v3.2 (Codex peer-reviewed) | 2026-02-21 |
 | [zenote-comprehensive-review-Codex.md](reviews/zenote-comprehensive-review-Codex.md) | Comprehensive security/code review by Codex | 2025-12-28 |
 | [share-token-security-analysis-claude.md](analysis/share-token-security-analysis-claude.md) | Share link token security verification | 2025-12-28 |
@@ -151,6 +151,7 @@ Currently in-progress implementation plans and follow-ups.
 
 | Document | Description | Date |
 |----------|-------------|------|
+| [account-deletion-workflow-plan.md](plans/account-deletion-workflow-plan.md) | Server-owned account deletion workflow plan - implementation PR keeps offboarding disabled until production verification and throwaway-account deletion drill | 2026-06-21 |
 | [reliability-hardening-plan-codex.md](active/reliability-hardening-plan-codex.md) | Reliability hardening plan — items 1-3 implemented (PR #163): blocked sync recovery, safe hydration, E2EE telemetry. Items 4-5 deferred. | 2026-03-10 |
 | [launch-critical-fixes-plan-codex.md](active/launch-critical-fixes-plan-codex.md) | Launch-critical fix plan for `#121`, `#154`, `#126`, `#133` — **COMPLETE** (PR #164): sanitizer hardening, vault restore verification, search shortcut replacement, editor save serialization | 2026-03-10 |
 | [2026-03-09-editor-calm-delight.md](plans/2026-03-09-editor-calm-delight.md) | **NEW** Editor calm & delight - 9 changes: sidebar toolbar, metadata collapse, writing surface polish | 2026-03-09 |

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -151,7 +151,7 @@ Currently in-progress implementation plans and follow-ups.
 
 | Document | Description | Date |
 |----------|-------------|------|
-| [account-deletion-workflow-plan.md](plans/account-deletion-workflow-plan.md) | Server-owned account deletion workflow plan - implementation PR keeps offboarding disabled until production verification and throwaway-account deletion drill | 2026-06-21 |
+| [account-deletion-workflow-plan.md](plans/account-deletion-workflow-plan.md) | Server-owned account deletion workflow plan and live-verification enablement record | 2026-06-21 |
 | [reliability-hardening-plan-codex.md](active/reliability-hardening-plan-codex.md) | Reliability hardening plan — items 1-3 implemented (PR #163): blocked sync recovery, safe hydration, E2EE telemetry. Items 4-5 deferred. | 2026-03-10 |
 | [launch-critical-fixes-plan-codex.md](active/launch-critical-fixes-plan-codex.md) | Launch-critical fix plan for `#121`, `#154`, `#126`, `#133` — **COMPLETE** (PR #164): sanitizer hardening, vault restore verification, search shortcut replacement, editor save serialization | 2026-03-10 |
 | [2026-03-09-editor-calm-delight.md](plans/2026-03-09-editor-calm-delight.md) | **NEW** Editor calm & delight - 9 changes: sidebar toolbar, metadata collapse, writing surface polish | 2026-03-09 |

--- a/docs/active/launch-readiness-assessment.md
+++ b/docs/active/launch-readiness-assessment.md
@@ -2,8 +2,8 @@
 
 **Author:** Claude (Opus 4.5 → Opus 4.6)
 **Created:** 2025-12-26
-**Last Updated:** 2026-03-10
-**Status:** Active — Not Yet Launch-Ready
+**Last Updated:** 2026-06-21
+**Status:** Active - Launch-Critical Security Complete
 
 ---
 
@@ -17,7 +17,37 @@
 | Assessment 4 | 2025-12-28 | ~93% | Codex review fixes complete |
 | Assessment 5 | 2026-01-07 | ~95% | Full offline editing complete (PR #48) |
 | Assessment 6 | 2026-01-11 | ~100% | Phase 0 launch polish complete |
-| **Assessment 7** | **2026-03-10** | **Not ready** | **Codex deep-dive: trust/recovery gaps in offboarding, sharing, sync** |
+| Assessment 7 | 2026-03-10 | Not ready | Codex deep-dive: trust/recovery gaps in offboarding, sharing, sync |
+| **Assessment 8** | **2026-06-21** | **Launch-critical security complete** | **PR #192 hardening complete; production SQL verification reported passed** |
+
+---
+
+# Assessment 8 (2026-06-21)
+
+**Reviewer:** Codex App (GPT-5) - launch security closeout
+**Primary artifact:** [`code-review-b8a4c2e1.md`](../reviews/code-review-b8a4c2e1.md)
+**Verdict:** Launch-critical code and E2EE hardening are complete. The previous hard gate, live Supabase verification for `launch_security_hardening.sql` and related RLS/RPC grants, is recorded as passed with `launch_security_verification_passed`.
+
+## Executive Summary
+
+Security hardening is now complete for the public-launch scope. PR #192 closed the E2EE fail-closed issues that remained after the March readiness pass: encrypted-note invariants are centralized, authenticated note persistence rejects plaintext rows and queue payloads, the launch SQL migration enforces encrypted-only server rows, core RLS/share RPC behavior is captured in repo migrations, and the temporary legacy repair surface is gone from the launch build.
+
+The remaining launch decisions are not security-hardening blockers:
+
+1. **Re-auth flag:** `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`. With self-serve offboarding disabled, this mainly affects Full Backup export. Decide explicitly whether to keep that launch tradeoff or flip it before a broader public push.
+2. **Bundle regression:** Local build on 2026-06-21 reports `main` at 778.61 KB / 240.48 KB gzip and `Editor` at 443.26 KB / 133.96 KB gzip. This is worth a code-split pass soon, but it does not reopen the E2EE/security launch gate.
+3. **Future hardening:** A seeded SQL regression harness, typed security errors, duplicate cleanup-function consolidation, and external Semgrep/Gitleaks-style scans remain useful follow-ups.
+
+## Security Closeout
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Client/runtime encrypted-note invariant | Complete | Shared `noteEncryptionInvariant` validation now covers hydration, realtime, sync queue processing, conflict resolution, and encrypted reads. |
+| Authenticated plaintext write fallbacks | Complete | Launch code requires encrypted note payloads; legacy plaintext helpers are disabled outside tests. |
+| Database encrypted-only enforcement | Complete | `supabase/migrations/launch_security_hardening.sql` enforces encrypted-only server rows and empty plaintext title/content fields. |
+| Core RLS and share RPC hardening | Complete | Migration resets owner-scoped RLS policies and restricts public sharing to ciphertext-only `fetch_shared_note` RPC access. |
+| Live Supabase verification | Complete by recorded evidence | Review artifact records production verification output: `launch_security_verification_passed`. |
+| Offboarding trust gap | Closed for launch | Self-serve account deletion stays hidden; the server-owned workflow is being implemented behind the disabled flag and remains gated on production verification plus a throwaway-account deletion drill. |
 
 ---
 
@@ -200,11 +230,12 @@ Category 1 is the most dangerous for launch: users forgive missing features but 
 | 4. Social metadata | 15 min | **Done** | OG URL updated to yidhan.vercel.app |
 | 5. Verify `/demo` route | 15 min | **Done** | Catch-all SPA rewrite added to vercel.json |
 | 6. Guard `deleteNoteFromServer` | 2-3 hours | **Done** | Discriminated union return, conflict surfaced via ConflictModal |
-| 12. Audit Supabase policies | 1 hour (manual) | **Not started** | Manual verification needed |
+| 12. Audit Supabase policies | 1 hour (manual) | **Done** | Superseded by PR #192 production verification: `launch_security_verification_passed` |
 
 ### Remaining before launch
-- **Re-auth flag:** Flip `REAUTH_FOR_SENSITIVE_ACTIONS` to `true` in `src/config/featureFlags.ts` (~1 min) — disabled for pre-launch solo use, see Item 7
-- **Item 12:** Manually audit live Supabase sharing policies
+- **No launch-critical security blockers remain** in the repo docs after PR #192 and recorded live SQL verification.
+- **Re-auth flag:** Decide explicitly whether to keep `REAUTH_FOR_SENSITIVE_ACTIONS = false` for launch. With offboarding disabled, the practical exposure is Full Backup export, not account deletion.
+- **Bundle follow-up:** Main bundle is now 778.61 KB / 240.48 KB gzip. Schedule a performance/code-split pass, but treat it as a non-blocking launch follow-up.
 
 ---
 

--- a/docs/active/launch-readiness-assessment.md
+++ b/docs/active/launch-readiness-assessment.md
@@ -34,7 +34,7 @@ Security hardening is now complete for the public-launch scope. PR #192 closed t
 
 The remaining launch decisions are not security-hardening blockers:
 
-1. **Re-auth flag:** `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`. With self-serve offboarding disabled, this mainly affects Full Backup export. Decide explicitly whether to keep that launch tradeoff or flip it before a broader public push.
+1. **Re-auth flag:** `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`. Account deletion now has its own server-verified password/email-OTP confirmation path, so this mainly affects Full Backup export. Decide explicitly whether to keep that launch tradeoff or flip it before a broader public push.
 2. **Bundle regression:** Local build on 2026-06-21 reports `main` at 778.61 KB / 240.48 KB gzip and `Editor` at 443.26 KB / 133.96 KB gzip. This is worth a code-split pass soon, but it does not reopen the E2EE/security launch gate.
 3. **Future hardening:** A seeded SQL regression harness, typed security errors, duplicate cleanup-function consolidation, and external Semgrep/Gitleaks-style scans remain useful follow-ups.
 
@@ -47,7 +47,7 @@ The remaining launch decisions are not security-hardening blockers:
 | Database encrypted-only enforcement | Complete | `supabase/migrations/launch_security_hardening.sql` enforces encrypted-only server rows and empty plaintext title/content fields. |
 | Core RLS and share RPC hardening | Complete | Migration resets owner-scoped RLS policies and restricts public sharing to ciphertext-only `fetch_shared_note` RPC access. |
 | Live Supabase verification | Complete by recorded evidence | Review artifact records production verification output: `launch_security_verification_passed`. |
-| Offboarding trust gap | Closed for launch | Self-serve account deletion stays hidden; the server-owned workflow is being implemented behind the disabled flag and remains gated on production verification plus a throwaway-account deletion drill. |
+| Offboarding trust gap | Closed and enabled | Server-owned account deletion is enabled after production verification, scheduler smoke testing, and a throwaway-account deletion drill. |
 
 ---
 
@@ -82,7 +82,9 @@ Category 1 is the most dangerous for launch: users forgive missing features but 
 
 **Fix:** Hide the offboarding link from SettingsModal for launch. Ship proper server-side deletion (edge function + cron) as a dedicated trust workstream later.
 
-**2026-06-20 update:** Addressed on `codex/security-launch-hardening` with `ACCOUNT_OFFBOARDING_ENABLED = false`; the Settings entry point is hidden and public support/privacy copy no longer promises self-serve deletion.
+**2026-06-20 update:** Addressed on `codex/security-launch-hardening` with `ACCOUNT_OFFBOARDING_ENABLED = false`; the Settings entry point was hidden and public support/privacy copy no longer promised self-serve deletion.
+
+**2026-06-23 update:** Superseded by the server-owned account deletion workflow: production verification, scheduler smoke testing, and a throwaway OAuth account deletion drill passed, so `ACCOUNT_OFFBOARDING_ENABLED = true`.
 
 **Effort:** Small (hide feature) / Large (build real backend)
 
@@ -162,9 +164,9 @@ Category 1 is the most dangerous for launch: users forgive missing features but 
 
 **Evidence:** [`ReAuthModal.tsx:78`](../../src/components/ReAuthModal.tsx#L78)
 
-**Why defer:** With offboarding disabled (item 1), the main action gated by re-auth is full backup export. Low user count at launch = low risk. Build proper `signInWithOAuth({ prompt: 'consent' })` step-up auth as part of the offboarding trust workstream.
+**Why defer:** Account deletion now has its own server-verified password/email-OTP confirmation path. The main remaining action gated by `REAUTH_FOR_SENSITIVE_ACTIONS` is full backup export. Low user count at launch = low risk.
 
-**Update (2026-05-25, PR #187):** The ReAuthModal is now gated behind `REAUTH_FOR_SENSITIVE_ACTIONS` in [`src/config/featureFlags.ts`](../../src/config/featureFlags.ts), defaulted to `false` to remove friction during solo pre-launch use. Before any public launch, flip the flag to `true` so Full Backup and "Let Go" require re-auth again.
+**Update (2026-06-23):** Account deletion no longer depends on this global flag; "Letting Go" always uses the account-deletion confirmation path before creating the server-owned deletion request. Keep the global flag decision scoped to Full Backup unless more sensitive actions are added.
 
 ### 8. Cross-device tag sync (DEFERRED)
 
@@ -224,7 +226,7 @@ Category 1 is the most dangerous for launch: users forgive missing features but 
 
 | Item | Effort | Status | Notes |
 |------|--------|--------|-------|
-| 1. Disable "Letting Go" | 30 min | **Done on branch** | Hidden behind `ACCOUNT_OFFBOARDING_ENABLED = false`; backend deletion workstream still required before re-enabling |
+| 1. Disable "Letting Go" | 30 min | **Superseded** | Re-enabled after the server-owned workflow, production verification, scheduler smoke test, and throwaway-account deletion drill passed |
 | 2. Share key sessionStorage | 1 hour | **Done** | New `shareRoute.ts` module, all reload paths covered |
 | 3. Fix backup copy | 15 min | **Partial** | Removed "(includes share links)" — label now just "Full Backup" |
 | 4. Social metadata | 15 min | **Done** | OG URL updated to yidhan.vercel.app |
@@ -234,7 +236,7 @@ Category 1 is the most dangerous for launch: users forgive missing features but 
 
 ### Remaining before launch
 - **No launch-critical security blockers remain** in the repo docs after PR #192 and recorded live SQL verification.
-- **Re-auth flag:** Decide explicitly whether to keep `REAUTH_FOR_SENSITIVE_ACTIONS = false` for launch. With offboarding disabled, the practical exposure is Full Backup export, not account deletion.
+- **Re-auth flag:** Decide explicitly whether to keep `REAUTH_FOR_SENSITIVE_ACTIONS = false` for launch. Account deletion has its own server-verified confirmation path, so the practical exposure is Full Backup export.
 - **Bundle follow-up:** Main bundle is now 778.61 KB / 240.48 KB gzip. Schedule a performance/code-split pass, but treat it as a non-blocking launch follow-up.
 
 ---

--- a/docs/analysis/security-launch-assessment-codex-2026-06-08.md
+++ b/docs/analysis/security-launch-assessment-codex-2026-06-08.md
@@ -1,8 +1,8 @@
 # Yidhan Security Launch Assessment
 
-**Version:** 1.1
-**Last Updated:** 2026-06-08
-**Status:** Complete
+**Version:** 1.2
+**Last Updated:** 2026-06-21
+**Status:** Complete - Launch-Critical Hardening Closed
 **Author:** Codex (GPT-5)
 **Review ID:** d2c8a91f
 
@@ -14,13 +14,21 @@
 
 ---
 
-## Executive Summary
+## Current Status (2026-06-21)
+
+This document preserves the initial launch security audit and its evidence. Its original "not ready" verdict is now historical for the launch-critical E2EE scope.
+
+PR #192 completed the hardening work tracked by this assessment and the follow-up multi-agent review. The repo now enforces a single encrypted-note launch invariant across client persistence, sync queue processing, realtime/server hydration, conflict resolution, and database rows. The review artifact records live Supabase verification output as `launch_security_verification_passed`, closing the previous backend-proof gate for launch.
+
+Remaining work is future hardening, not a launch-critical security blocker: automated seeded SQL regression tests, typed security error classes, cleanup-function consolidation, external Semgrep/Gitleaks-style scans, and production verification plus a throwaway-account deletion drill before self-serve offboarding is re-enabled.
+
+## Initial Executive Summary (2026-06-08)
 
 Yidhan does not yet meet the launch bar for "full E2EE" or "bulletproof security." The core cryptographic primitives are mostly sound: note title/content encryption uses AES-GCM with random 96-bit IVs, note/user AAD binding, and HMAC content hashes; encrypted share links use per-share random keys and token-bound AAD. Focused crypto/security tests passed.
 
 At the time of the initial audit, the blockers were around enforcement and launch hardening, not the AES implementation. The app accepted plaintext note rows, had plaintext fallback write paths, had a weak passphrase policy for an offline-guessable verifier, lacked reproducible core RLS migrations, exposed unscoped SECURITY DEFINER cleanup functions, had current DOMPurify advisories while rendering user HTML, and only applied CSP/security headers to shared-note routes.
 
-**Launch verdict at initial audit:** Not ready for public launch with current E2EE/privacy claims. The first remediation pass has since addressed several client/runtime findings locally, but backend/database verification and enforcement remain required before a strong public E2EE claim.
+**Launch verdict at initial audit:** Not ready for public launch with current E2EE/privacy claims. This verdict was superseded on 2026-06-21 after PR #192 and recorded production SQL verification closed the launch-critical hardening gate.
 
 ## Plain-English Security Model
 
@@ -31,7 +39,7 @@ The confusing part is that "E2EE app" is not one single property. For Yidhan, it
 3. Backend/database enforcement: Supabase must reject bad writes even if someone bypasses the UI and calls the API directly.
 4. Operational/web hardening: CSP headers, dependency hygiene, Sentry scrubbing, share-link secrecy, account deletion, RLS, and logs must support the privacy promise.
 
-The first remediation pass on branch `codex/security-launch-hardening` mainly addressed layers 1, 2, and part of 4. It made encrypted accounts fail closed in client and sync paths, strengthened passphrase setup, hardened sanitization and clipboard handling, added app-wide security headers, deepened Sentry scrubbing, and cleaned the dependency audit. The remaining public-launch blockers are mostly layer 3: live Supabase/RLS proof, database-level encrypted-write enforcement, share RPC/function scoping, and backend deletion guarantees.
+The first remediation pass on branch `codex/security-launch-hardening` mainly addressed layers 1, 2, and part of 4. It made encrypted accounts fail closed in client and sync paths, strengthened passphrase setup, hardened sanitization and clipboard handling, added app-wide security headers, deepened Sentry scrubbing, and cleaned the dependency audit. At the time, the remaining public-launch blockers were mostly layer 3: live Supabase/RLS proof, database-level encrypted-write enforcement, share RPC/function scoping, and backend deletion guarantees. Those launch-critical layer 3 items were later closed by PR #192 and recorded production SQL verification.
 
 ## What Was Risky
 
@@ -71,7 +79,7 @@ After the first client/runtime hardening pass, the remaining gaps were backend p
 4. Offboarding deletion guarantee: if public copy promises account deletion, the backend must actually perform and audit that deletion.
 5. External scans: Semgrep/Gitleaks or equivalent tooling should still run before launch.
 
-The second fix pass below adds repo-level backend enforcement for these items. The remaining launch work is to apply and verify that migration against the live Supabase project.
+The second fix pass below added repo-level backend enforcement for these items. The remaining launch work at that time was to apply and verify the migration against the live Supabase project; the later PR #192 review artifact records that verification as passed.
 
 ## Second Fix Pass: Backend Enforcement
 
@@ -84,10 +92,10 @@ On 2026-06-20, branch `codex/security-launch-hardening` added repo-level backend
 - Hardened `fetch_shared_note` with token-shape validation, note/share owner matching, explicit `search_path`, explicit grants, and explicit revokes from `PUBLIC`.
 - Added encrypted share-row constraints and a trigger preventing direct API writes from extending share expiry beyond 30 days from the write.
 - Revoked normal-client access to global `SECURITY DEFINER` cleanup and timestamp-restore functions, leaving them for service-owned execution.
-- Hid self-serve "Letting Go" offboarding behind a disabled launch flag and corrected public support/privacy copy so the app no longer promises account deletion before a server-owned deletion workflow exists.
+- Hid self-serve "Letting Go" offboarding behind a disabled launch flag and corrected public support/privacy copy so the app no longer promises account deletion before the server-owned workflow is live-verified.
 - Used a temporary legacy encryption repair tool for the pre-hardening window, then removed the runtime repair surface after all retained accounts had encrypted rows and `launch_security_hardening.sql` verification passed.
 
-This does not replace live Supabase verification. Before public launch, the migration must be applied to the production project and RLS/function grants should be verified against the live database.
+This work was later paired with live Supabase verification. The PR #192 review artifact records the production verification output as `launch_security_verification_passed`.
 
 ## No Active Users Impact
 
@@ -111,7 +119,7 @@ Skipped or limited coverage:
 
 - Semgrep was not installed.
 - Gitleaks was not installed.
-- Live Supabase policies were not inspected, so the repo can show intended behavior but cannot prove production DB state.
+- Live Supabase policies were not inspected during the initial audit, so the 2026-06-08 repo state could show intended behavior but could not prove production DB state. Later verification was provided and recorded in the PR #192 review artifact.
 - No professional penetration test, dynamic browser attack testing, or live account abuse testing was performed.
 
 ## Validation Results
@@ -427,4 +435,6 @@ Strongly recommended before launch:
 
 ## Final Verdict
 
-Yidhan has the foundation for real E2EE, but the app does not yet prove or enforce full E2EE end to end. The launch bar should be: no plaintext authenticated note writes, no trusted plaintext server rows for encrypted accounts, reproducible RLS, fixed sanitizer advisories, and app-wide browser hardening. Until those are complete, the public claim should be softened or launch should wait.
+The initial 2026-06-08 verdict was "do not launch with full E2EE claims yet." As of the 2026-06-21 closeout, that verdict is superseded for the launch-critical E2EE hardening scope: authenticated plaintext note writes are blocked, trusted plaintext server rows are rejected, core RLS/share RPC hardening is captured in repo SQL, app-wide browser hardening is in place, and live SQL verification is recorded as passed.
+
+Yidhan can now make the launch E2EE claim with a clearer conscience, provided public copy stays honest about the remaining boundaries: tags and metadata are not encrypted, self-serve account deletion is disabled until production verification and a throwaway-account deletion drill pass, and "Remember this browser" remains an opt-in local key-storage tradeoff.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,7 +57,8 @@ Key open items: proof rail links, below-the-fold second act, 6 deferred signatur
 
 | Item | Priority | Source |
 |------|----------|--------|
-| Restore self-serve offboarding in a tiny follow-up only after the server-owned account deletion workflow passes production verification and a throwaway-account deletion drill. The implementation PR must keep `ACCOUNT_OFFBOARDING_ENABLED = false`, keep deletion copy silent, and leave re-enablement as a separate verified step. | P1 | [Account deletion workflow plan](plans/account-deletion-workflow-plan.md) |
+| Resolve the Supabase built-in email sender limit for OAuth account deletion verification. Google/GitHub users rely on email OTP verification, and Supabase's built-in sender is capped at 2 auth emails/hour, so production reliability needs custom SMTP or another production-grade verification path. | P1 | Account deletion OAuth test |
+| Soften the account deletion completion UX. Instead of an abrupt small dialog saying "Your account is fading quietly. See you if you return." followed by immediate logout, show the final confirmation before logout and transition through the completion steps slowly over a few seconds. | P1 | Account deletion UX test |
 | Treat applied Supabase migrations as append-only. Future security/RLS tightening should use forward migrations instead of rewriting historical migration SQL, so restore paths and audit history stay truthful. | P2 | Claude review on PR #193 |
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,7 +57,7 @@ Key open items: proof rail links, below-the-fold second act, 6 deferred signatur
 
 | Item | Priority | Source |
 |------|----------|--------|
-| Restore self-serve offboarding only after real server-owned account deletion exists. Launch hardening paused the flow with `ACCOUNT_OFFBOARDING_ENABLED = false`, hid "Letting Go" from Settings, and removed deletion promises from Privacy/Support copy. | P1 | [Security launch assessment](analysis/security-launch-assessment-codex-2026-06-08.md) |
+| Restore self-serve offboarding in a tiny follow-up only after the server-owned account deletion workflow passes production verification and a throwaway-account deletion drill. The implementation PR must keep `ACCOUNT_OFFBOARDING_ENABLED = false`, keep deletion copy silent, and leave re-enablement as a separate verified step. | P1 | [Account deletion workflow plan](plans/account-deletion-workflow-plan.md) |
 | Treat applied Supabase migrations as append-only. Future security/RLS tightening should use forward migrations instead of rewriting historical migration SQL, so restore paths and audit history stay truthful. | P2 | Claude review on PR #193 |
 
 ---

--- a/docs/plans/account-deletion-workflow-plan.md
+++ b/docs/plans/account-deletion-workflow-plan.md
@@ -1,0 +1,565 @@
+# Account Deletion Workflow - Implementation Plan
+
+**Version:** 1.1
+**Last Updated:** 2026-06-21
+**Status:** Draft - implementation spec, feature remains disabled until live verification
+**Author:** Claude (Opus 4.8)
+**Reviewed/Expanded:** Codex App (GPT-5)
+
+---
+
+## Original Prompt
+
+> I forgot about this... what's missing for: "No account-deletion promise until the server-owned deletion workflow exists. Offboarding stays disabled, and Privacy/Support copy stays silent on deletion." [followed by] yes [write it up as an implementation plan]
+
+---
+
+## Goal
+
+Make "Letting Go" account offboarding a real, server-owned, auditable account deletion workflow before it is re-enabled. Today the UI and 14-day grace-period UX exist, but deletion is not server-enforced: `initiateOffboarding()` writes `departing_at` into user-writable `user_metadata`, `cancelOffboarding()` clears that same metadata, and `daysUntilRelease` is client-side math.
+
+This work adds the missing backend half:
+
+1. A server-authoritative deletion-request store.
+2. A server-verifiable re-auth/confirmation gate for account deletion.
+3. A service-role worker that deletes app data and the `auth.users` row.
+4. Schedule wiring for the worker.
+5. Audit logging for every attempt, skip, failure, and release.
+6. Verification scripts so production state can be proven before copy or flags are restored.
+
+Out of scope:
+
+- Redesigning the Letting Go UX.
+- Changing the E2EE model.
+- Email notification lifecycle copy.
+- Re-enabling the feature or restoring deletion promises before live verification.
+
+---
+
+## Current State
+
+| Piece | Status | Evidence |
+|-------|--------|----------|
+| Letting Go modal + keepsakes export | Built | `src/components/LettingGoModal.tsx` |
+| Grace-period return / "Welcome back" flow | Built, but client-driven | `src/contexts/AuthContext.tsx` `isDeparting`, `daysUntilRelease` |
+| `initiateOffboarding` / `cancelOffboarding` | Built, metadata only | `src/contexts/AuthContext.tsx` |
+| Server-owned deletion job | Missing | No `supabase/functions/` directory |
+| Trusted deletion-request store | Missing | Current state uses user-writable `user_metadata.departing_at` |
+| Schedule / trigger | Missing | No account-deletion cron wiring |
+| Audit trail | Missing | No durable deletion audit table |
+| Real re-auth before deletion | Missing / faked | OAuth path in `ReAuthModal.tsx` only asks the user to type their email |
+| Feature gate | Disabled, correct | `ACCOUNT_OFFBOARDING_ENABLED = false` |
+
+---
+
+## Non-Negotiable Guardrails
+
+These are security requirements, not preferences.
+
+1. **Do not flip flags in the implementation PR.** Keep `ACCOUNT_OFFBOARDING_ENABLED = false` and `REAUTH_FOR_SENSITIVE_ACTIONS = false` until the migration, worker, schedule, tests, and live verification have all passed.
+2. **Do not restore Privacy/Support deletion copy in the implementation PR.** Copy restoration is a post-verification enablement step.
+3. **Do not use `user_metadata` as an authority.** It may be cleaned up or ignored, but the deletion trigger must read from `account_deletion_requests`.
+4. **Do not allow direct client writes to the deletion-request table.** Normal clients get read-only access to their own active request plus RPC execute privileges. Inserts/updates/status changes happen through controlled RPCs.
+5. **Do not rely on UI-only re-auth.** A React `lastReauthAt` timestamp prevents accidental clicks, but it does not stop direct RPC calls from a valid session. `request_account_deletion` must require a server-verifiable confirmation token or equivalent proof.
+6. **Never expose service-role credentials to client code.** The service-role key exists only in Supabase Edge Function secrets or scheduler secrets.
+7. **The worker must be idempotent.** Re-running it must not double-delete, skip audit, or mark partial work as released.
+8. **Cancellation wins until the destructive boundary.** The worker must re-check cancellation after claiming a row and immediately before deleting app/auth data.
+9. **Partial failure never equals release.** Failures must produce `status = 'failed'`, an error detail, retry metadata, and an audit row.
+10. **Migrations are append-only.** Add a new forward migration; do not rewrite previous migrations.
+
+---
+
+## PR Scope vs Enablement Scope
+
+The implementation PR should include:
+
+- SQL migration.
+- Edge Function worker.
+- Scheduler setup script with placeholders/secrets instructions.
+- Client rewiring behind existing disabled feature flags.
+- Re-auth/confirmation plumbing.
+- Tests and verification scripts.
+- Documentation of the final live-verification and flag-flip steps.
+
+The implementation PR should not include:
+
+- `ACCOUNT_OFFBOARDING_ENABLED = true`.
+- `REAUTH_FOR_SENSITIVE_ACTIONS = true`.
+- Restored public deletion promises in Privacy/Support copy.
+- Production secrets, function URLs with real tokens, or live scheduler credentials.
+
+After live production verification passes, do a tiny follow-up change that flips the feature/copy. That follow-up should be easy to review because the sensitive machinery will already be proven.
+
+---
+
+## Architecture
+
+### Components
+
+1. **Database migration**
+   - `account_deletion_requests`
+   - `account_deletion_audit`
+   - `sensitive_action_confirmations` or an equivalent server-verifiable proof store
+   - request/cancel/claim/mark RPCs
+   - RLS, grants, revokes, and comments
+
+2. **Edge Function: request confirmation**
+   - Required unless the PR implements an equivalent server-verifiable proof mechanism.
+   - Mints short-lived confirmation tokens only after real credential or challenge proof.
+
+3. **Edge Function: process deletions**
+   - Uses service role.
+   - Claims due rows.
+   - Deletes app data.
+   - Deletes the Supabase Auth user via Admin API.
+   - Writes audit records.
+
+4. **Scheduler**
+   - Preferred: Supabase `pg_cron` + `pg_net` calling the worker with a secret header.
+   - Acceptable fallback: external scheduler calling the Edge Function URL with a shared secret.
+
+5. **Client**
+   - Reads server deletion request state.
+   - Initiates cancellation via RPC.
+   - Requests deletion only after server-verifiable confirmation.
+   - Keeps the existing flags disabled until live verification.
+
+---
+
+## Design Decisions
+
+### D1. Source of Truth: `account_deletion_requests`
+
+Use a dedicated server-authoritative table. Do not use `auth.users.raw_user_meta_data` / `user_metadata` as deletion input.
+
+Suggested shape:
+
+```sql
+account_deletion_requests
+  user_id                uuid primary key references auth.users(id) on delete cascade
+  requested_at           timestamptz not null default now()
+  release_at             timestamptz not null
+  cancelled_at           timestamptz
+  status                 text not null default 'pending'
+  attempt_count          integer not null default 0
+  last_attempt_at        timestamptz
+  next_attempt_at        timestamptz
+  processing_started_at  timestamptz
+  processing_worker_id   text
+  released_at            timestamptz
+  error                  text
+  created_at             timestamptz not null default now()
+  updated_at             timestamptz not null default now()
+```
+
+Constraints:
+
+- `status in ('pending', 'processing', 'cancelled', 'released', 'failed')`
+- `release_at >= requested_at`
+- `attempt_count >= 0`
+- `cancelled_at is not null` when `status = 'cancelled'`
+- `released_at is not null` when `status = 'released'` if the row still exists
+
+Client privileges:
+
+- `authenticated` may `SELECT` only its own row.
+- `authenticated` must not have direct `INSERT`, `UPDATE`, or `DELETE`.
+- `anon` gets no table access.
+- `service_role` can manage rows through worker RPCs or service client access.
+
+### D2. Request/Cancel RPCs
+
+Create explicit RPCs with `SECURITY DEFINER`, `SET search_path = public, pg_temp`, and explicit grants/revokes.
+
+`request_account_deletion(confirmation_token text)`:
+
+- Requires `auth.uid()` to be non-null.
+- Validates a fresh server-verifiable confirmation token for `auth.uid()` and action `account_deletion`.
+- Consumes the confirmation token atomically.
+- Creates or resets the user's request:
+  - `requested_at = now()`
+  - `release_at = now() + interval '14 days'`
+  - `cancelled_at = null`
+  - `status = 'pending'`
+  - retry/processing/error fields cleared
+- Returns the request row needed by the client.
+
+`cancel_account_deletion()`:
+
+- Requires `auth.uid()` to be non-null.
+- Only operates on the caller's request.
+- Sets `cancelled_at = now()`, `status = 'cancelled'`, clears processing fields.
+- Returns the updated request row.
+- Must be safe if there is no active request.
+
+Important: cancellation may occur close to release time. The worker must re-check cancellation even if the row was claimed moments earlier.
+
+### D3. Server-Verifiable Re-Auth / Confirmation
+
+UI-only re-auth is not enough. A malicious or buggy client with a valid session could call a normal RPC directly. The deletion-request RPC needs proof that the user recently completed a stronger challenge.
+
+Recommended table:
+
+```sql
+sensitive_action_confirmations
+  id             uuid primary key default gen_random_uuid()
+  user_id        uuid not null references auth.users(id) on delete cascade
+  action         text not null
+  token_hash     text not null unique
+  method         text not null
+  created_at     timestamptz not null default now()
+  expires_at     timestamptz not null
+  consumed_at    timestamptz
+```
+
+Access:
+
+- No `anon` or `authenticated` table access.
+- Confirmation creation is service-owned.
+- `request_account_deletion(confirmation_token)` validates by hashing the supplied token and consuming the matching row.
+
+Minimum acceptable confirmation behavior:
+
+- **Email/password users:** verify the current password before minting a confirmation token. This can be done in a dedicated Edge Function over HTTPS. The function should verify credentials against Supabase Auth, confirm the returned user matches the current session user, store only a token hash, and return the raw one-time token to the client.
+- **OAuth users:** do not keep the current typed-email fallback. Either:
+  1. implement and test a provider challenge flow that mints a server-side confirmation token only after the OAuth redirect completes for the same user, using `signInWithOAuth({ provider, options: { redirectTo, queryParams: { prompt: 'consent' } } })` or a provider-specific stronger prompt where supported; or
+  2. implement an email-OTP confirmation flow and mint the confirmation token only after server-side OTP verification; or
+  3. keep account deletion unavailable for OAuth users until one of the above is proven.
+
+Do not claim OAuth re-auth is complete just because the client redirected through OAuth. Provider prompting behavior is provider-dependent and must be verified in E2E/manual testing before the feature is enabled.
+
+### D4. Audit Trail
+
+Create `account_deletion_audit` as append-only operational evidence. It should not reference `auth.users` with a foreign key because the user row will be deleted.
+
+Suggested shape:
+
+```sql
+account_deletion_audit
+  id              bigserial primary key
+  user_id         uuid
+  user_id_hash    text
+  requested_at    timestamptz
+  release_at      timestamptz
+  attempt_count   integer
+  outcome         text not null
+  detail          text
+  worker_id       text
+  created_at      timestamptz not null default now()
+```
+
+Outcomes:
+
+- `processing_started`
+- `released`
+- `failed`
+- `skipped_cancelled`
+- `no_op`
+
+Access:
+
+- No normal client table access.
+- Service-owned writes only.
+- If raw `user_id` retention is a concern, populate `user_id_hash` and decide whether raw `user_id` should be nullable or purged after a retention window.
+
+The worker should append `processing_started` before destructive work and append a final outcome afterward. This avoids a total audit gap if the auth user is deleted but a later final audit write fails.
+
+### D5. Worker Claiming, Locking, and Retry Semantics
+
+Do not let concurrent worker invocations process the same user.
+
+Add a service-only claim RPC, for example `claim_due_account_deletions(batch_limit integer, worker_id text)`, that:
+
+- Runs in a database transaction.
+- Selects due rows with `FOR UPDATE SKIP LOCKED`.
+- Claims rows where:
+  - `status in ('pending', 'failed')`
+  - `cancelled_at is null`
+  - `release_at <= now()`
+  - `next_attempt_at is null or next_attempt_at <= now()`
+  - retry limit has not been exceeded
+- Updates claimed rows to:
+  - `status = 'processing'`
+  - `processing_started_at = now()`
+  - `processing_worker_id = worker_id`
+  - `attempt_count = attempt_count + 1`
+  - `last_attempt_at = now()`
+- Returns the rows needed by the worker.
+
+Failure handling:
+
+- On failure, mark the row `failed`.
+- Store sanitized `error`.
+- Set `next_attempt_at` using bounded backoff.
+- Append a `failed` audit row.
+- Never mark `released` unless app data deletion and Admin API user deletion both succeeded.
+
+Stale processing handling:
+
+- Verification/worker logic should detect rows stuck in `processing` beyond a timeout, e.g. 30-60 minutes.
+- Either a recovery RPC resets them to `failed` with retry metadata, or the claim RPC treats stale processing rows as retryable after timeout.
+
+### D6. Deletion Worker
+
+Create `supabase/functions/process-account-deletions/`.
+
+Environment/secrets:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `PROCESS_ACCOUNT_DELETIONS_SECRET` or equivalent scheduler secret
+
+Request validation:
+
+- Accept only `POST`.
+- Require a secret header from the scheduler.
+- Do not accept arbitrary user IDs from the request body.
+- Worker always processes due rows claimed from the database.
+
+Processing sequence for each claimed row:
+
+1. Append `processing_started` audit.
+2. Re-read the request row.
+3. If `cancelled_at is not null` or `status = 'cancelled'`, append `skipped_cancelled`, mark cancelled, and stop.
+4. Delete app data in FK-safe order:
+   - `note_shares` for `user_id`
+   - `note_tags` linked to the user's notes or tags
+   - `notes` for `user_id`
+   - `tags` for `user_id`
+   - future Storage objects, if any exist
+5. Re-check the request row again for cancellation immediately before auth deletion.
+6. Call `supabase.auth.admin.deleteUser(user_id)`.
+7. Append `released` audit.
+
+Notes:
+
+- Auth user deletion is intentionally last.
+- E2EE keys are not needed; this is row deletion only.
+- Service role bypasses RLS, but the code should still scope every delete by `user_id`.
+- If Admin API deletion succeeds but the final audit append fails, the `processing_started` row remains as evidence; the worker should log/report this as an incomplete audit condition.
+
+### D7. Scheduler
+
+Preferred scheduler: Supabase `pg_cron` + `pg_net`.
+
+Repository deliverable:
+
+- Add a setup script such as `supabase/account_deletion_schedule.sql`.
+- The script must use placeholders for function URL and secret names.
+- Do not commit real secrets.
+- Do not assume the schedule is active just because the file exists.
+
+Alternative scheduler:
+
+- GitHub Actions or another external scheduler may call the function URL.
+- It must use a secret header and must not include service-role credentials.
+
+The live verification step must confirm the chosen schedule exists and points at the intended function.
+
+### D8. Client Rewiring
+
+Update `AuthContext.tsx` so departure state comes from the server request table/RPC, not `user_metadata`.
+
+Required behavior:
+
+- Load the current user's deletion request after auth state settles.
+- `isDeparting` is true only when server state is active (`pending`, possibly `processing` before release cleanup).
+- `daysUntilRelease` is computed from server `release_at`.
+- `initiateOffboarding` calls the confirmation flow and then `request_account_deletion(confirmation_token)`.
+- `cancelOffboarding` calls `cancel_account_deletion()`.
+- The UI should tolerate stale legacy `user_metadata.departing_at` but not trust it.
+- On successful request, sign out as today only after the server request exists.
+- On successful cancellation, refresh server request state before showing "Welcome back."
+
+Type updates:
+
+- Extend `src/types/database.ts` for new tables/functions.
+- Update `src/test/test-utils.tsx` auth mocks as needed.
+
+### D9. ReAuthModal and Sensitive Actions
+
+Replace the OAuth typed-email fallback. It is not re-authentication.
+
+Implementation expectations:
+
+- Email/password path should verify password and mint a server-side confirmation token for account deletion.
+- OAuth path must be one of the proven options in D3; otherwise deletion remains unavailable for OAuth users.
+- `lastReauthAt` may remain a UX grace-window optimization for prompts, but it must not be the only gate for `request_account_deletion`.
+- Full Backup can continue using the existing disabled flag until the broader reauth strategy is enabled. Do not flip the flag in this PR.
+
+### D10. SQL and Grant Conventions
+
+Match the conventions in `supabase/migrations/launch_security_hardening.sql`:
+
+- `SECURITY DEFINER` functions use explicit `SET search_path = public, pg_temp`.
+- Revoke from `PUBLIC`, `anon`, and `authenticated` before granting only intended privileges.
+- RLS enabled on new tables.
+- Owner-scoped policies for normal user reads.
+- No public policies.
+- Use comments on tables/functions to document security intent.
+- Prefer check constraints for statuses rather than unreviewed free-form text.
+
+### D11. Verification Script
+
+Add `supabase/account_deletion_verification.sql`.
+
+It should be read-only and raise exceptions on failure. It should verify:
+
+- Tables exist.
+- RLS is enabled.
+- Expected policies exist.
+- No unexpected `anon`/`public` table policies exist.
+- `authenticated` cannot directly insert/update/delete request rows.
+- RPC grants are exactly as intended.
+- Service-only worker RPCs are not executable by `anon` or `authenticated`.
+- Audit table has no normal client write access.
+- Status/check constraints exist and are validated.
+- Scheduler object exists if using `pg_cron`.
+- Dry-run due-row query excludes cancelled requests.
+- No real deletion is performed.
+
+The script should end with a clear success row, e.g.:
+
+```sql
+SELECT 'account_deletion_verification_passed' AS result;
+```
+
+### D12. Documentation and Enablement Notes
+
+Update docs in the implementation PR to say:
+
+- The workflow is built but intentionally disabled pending live verification.
+- Public deletion copy remains silent until live verification passes.
+- The final enablement step is a small follow-up: flip flag(s), restore Settings entry/copy, and add changelog entry.
+
+Do not update public-facing copy to promise deletion until production verification has actually passed.
+
+---
+
+## Implementation Steps
+
+1. Create a feature branch.
+2. Add the SQL migration for request/audit/confirmation tables and RPCs.
+3. Add the deletion worker Edge Function.
+4. Add the confirmation Edge Function or an equivalent server-verifiable confirmation mechanism.
+5. Add scheduler setup script with placeholders and secret instructions.
+6. Add `supabase/account_deletion_verification.sql`.
+7. Rewire `AuthContext.tsx` to server request state.
+8. Replace the fake OAuth email confirmation path in `ReAuthModal.tsx`; leave OAuth deletion disabled if real proof is not implemented and tested.
+9. Add/update TypeScript DB types.
+10. Add tests per the test plan below.
+11. Run `npm run check`.
+12. Open a PR with flags still disabled and copy still silent.
+
+---
+
+## Test Plan
+
+### SQL / RLS
+
+If no local Supabase test harness is added, do not pretend Vitest covers RLS. Cover SQL/RLS with verification scripts and manual staging runs.
+
+Required checks:
+
+- User can read only own request row.
+- User cannot read another user's request row.
+- User cannot directly insert, update, or delete request rows.
+- `request_account_deletion` rejects missing/expired/consumed/wrong-user confirmation tokens.
+- `request_account_deletion` sets server-computed `requested_at` and `release_at`.
+- `cancel_account_deletion` affects only the caller's row.
+- Worker claim RPC is service-only.
+- Audit table is not writable by normal clients.
+
+### Worker
+
+Unit-test worker logic with injected/mocked Supabase clients:
+
+- Eligible row leads to app-row deletes, Admin API delete, and `released` audit.
+- Cancelled row is skipped and audited as `skipped_cancelled`.
+- Failure before auth delete sets `failed`, records sanitized error, sets retry metadata, and does not call `deleteUser`.
+- Admin API failure sets `failed` and retries later.
+- Stale `processing` rows are recoverable.
+- Re-running after success is a no-op.
+- Request body cannot select arbitrary users.
+- Missing scheduler secret returns non-2xx.
+
+### Re-auth / Confirmation
+
+- Email/password confirmation rejects wrong password.
+- Email/password confirmation mints a short-lived one-time token for the same user only.
+- Consumed/expired confirmation tokens cannot be reused.
+- OAuth typed-email fallback is removed.
+- OAuth deletion is either proven through a real challenge flow or blocked with clear UI/copy while feature remains disabled.
+
+### Client
+
+- `AuthContext` reads server request state.
+- `daysUntilRelease` uses server `release_at`.
+- Request flow does not sign out unless the server request succeeded.
+- Stay/cancel refreshes server state and clears the departure UI.
+- Legacy `user_metadata.departing_at` does not trigger deletion UI by itself.
+
+### E2E / Staging
+
+- Use a seeded throwaway account on staging.
+- Request deletion, verify server release date and grace UI.
+- Cancel, verify worker skips the account.
+- Request again, force `release_at` into the past on staging, run worker, verify:
+  - `notes`, `tags`, `note_tags`, `note_shares` rows are gone.
+  - `auth.users` row is gone.
+  - audit records exist.
+  - rerunning worker is safe.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Service-role key exposure | Key only in Edge Function/scheduler secrets; never in client or repo. |
+| User-writable deletion trigger | Trigger reads only `account_deletion_requests`; `user_metadata` ignored. |
+| Direct RPC call bypasses re-auth | `request_account_deletion` requires a server-verifiable confirmation token. |
+| Deleting a user who clicked Stay | Worker re-checks cancellation after claim and before auth delete. |
+| Concurrent workers double-process | Claim RPC uses row locking / `FOR UPDATE SKIP LOCKED` semantics. |
+| Partial deletion | Auth delete is last; failures mark `failed` with retry metadata. |
+| Missing audit after auth deletion | Append `processing_started` before destructive work and final outcome after. |
+| OAuth reauth is not actually fresh | Do not enable OAuth deletion unless a real challenge flow is implemented and verified. |
+| Accidental public promise before backend proof | Flags and copy remain disabled until live verification passes. |
+
+---
+
+## Definition of Done for Implementation PR
+
+- [ ] Append-only migration creates request, audit, and confirmation structures with RLS/grants/revokes.
+- [ ] Request/cancel RPCs are server-authoritative and do not trust `user_metadata`.
+- [ ] `request_account_deletion` requires server-verifiable confirmation.
+- [ ] Worker claims due rows safely and is idempotent.
+- [ ] Worker deletes app data and then `auth.users` via Admin API.
+- [ ] Cancellation is re-checked at execution time.
+- [ ] Failures produce retry metadata and audit rows.
+- [ ] Schedule setup script exists with placeholders and no committed secrets.
+- [ ] Verification script exists and ends with `account_deletion_verification_passed`.
+- [ ] Client reads server request state and no longer derives deletion state from `user_metadata`.
+- [ ] Fake OAuth email confirmation is removed or blocked for deletion.
+- [ ] Tests cover RPC assumptions, worker behavior, re-auth confirmation, client state, and staging/manual verification steps.
+- [ ] `npm run check` passes.
+- [ ] `ACCOUNT_OFFBOARDING_ENABLED` remains `false`.
+- [ ] `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`.
+- [ ] Privacy/Support deletion copy remains silent.
+
+---
+
+## Post-Verification Enablement DoD
+
+Only after the implementation PR is merged and live production verification passes:
+
+- [ ] Apply migration to production.
+- [ ] Deploy Edge Function(s).
+- [ ] Configure scheduler secrets and schedule.
+- [ ] Run `supabase/account_deletion_verification.sql` against production.
+- [ ] Run a staging or production throwaway-account deletion drill.
+- [ ] Record the verification output.
+- [ ] Flip `ACCOUNT_OFFBOARDING_ENABLED = true` in a small follow-up PR.
+- [ ] Decide whether `REAUTH_FOR_SENSITIVE_ACTIONS` should be flipped globally or kept separate from account deletion.
+- [ ] Restore Settings entry and public deletion copy.
+- [ ] Add changelog entry.

--- a/docs/plans/account-deletion-workflow-plan.md
+++ b/docs/plans/account-deletion-workflow-plan.md
@@ -1,8 +1,8 @@
 # Account Deletion Workflow - Implementation Plan
 
-**Version:** 1.1
-**Last Updated:** 2026-06-21
-**Status:** Draft - implementation spec, feature remains disabled until live verification
+**Version:** 1.2
+**Last Updated:** 2026-06-23
+**Status:** Complete - implemented and enabled after live verification
 **Author:** Claude (Opus 4.8)
 **Reviewed/Expanded:** Codex App (GPT-5)
 
@@ -11,6 +11,14 @@
 ## Original Prompt
 
 > I forgot about this... what's missing for: "No account-deletion promise until the server-owned deletion workflow exists. Offboarding stays disabled, and Privacy/Support copy stays silent on deletion." [followed by] yes [write it up as an implementation plan]
+
+---
+
+## Completion Record
+
+The server-owned account deletion workflow is implemented and enabled. Production verification passed with `account_deletion_verification_passed`, the scheduled `pg_net` smoke test returned HTTP 200 with `claimed: 0`, and a throwaway Google/OAuth account deletion drill completed with the worker outcome `released`.
+
+`ACCOUNT_OFFBOARDING_ENABLED` is now `true`. `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`; account deletion uses its dedicated server-verified password/email-OTP confirmation path.
 
 ---
 
@@ -32,7 +40,7 @@ Out of scope:
 - Redesigning the Letting Go UX.
 - Changing the E2EE model.
 - Email notification lifecycle copy.
-- Re-enabling the feature or restoring deletion promises before live verification.
+- Restoring public Privacy/Support deletion promises before a separate copy review.
 
 ---
 
@@ -41,14 +49,14 @@ Out of scope:
 | Piece | Status | Evidence |
 |-------|--------|----------|
 | Letting Go modal + keepsakes export | Built | `src/components/LettingGoModal.tsx` |
-| Grace-period return / "Welcome back" flow | Built, but client-driven | `src/contexts/AuthContext.tsx` `isDeparting`, `daysUntilRelease` |
-| `initiateOffboarding` / `cancelOffboarding` | Built, metadata only | `src/contexts/AuthContext.tsx` |
-| Server-owned deletion job | Missing | No `supabase/functions/` directory |
-| Trusted deletion-request store | Missing | Current state uses user-writable `user_metadata.departing_at` |
-| Schedule / trigger | Missing | No account-deletion cron wiring |
-| Audit trail | Missing | No durable deletion audit table |
-| Real re-auth before deletion | Missing / faked | OAuth path in `ReAuthModal.tsx` only asks the user to type their email |
-| Feature gate | Disabled, correct | `ACCOUNT_OFFBOARDING_ENABLED = false` |
+| Grace-period return / "Welcome back" flow | Built, server-driven | `src/contexts/AuthContext.tsx` reads `account_deletion_requests` |
+| `initiateOffboarding` / `cancelOffboarding` | Built, server-owned | `request_account_deletion` / `cancel_account_deletion` RPCs |
+| Server-owned deletion job | Built | `supabase/functions/process-account-deletions/` |
+| Trusted deletion-request store | Built | `public.account_deletion_requests` |
+| Schedule / trigger | Configured | `pg_cron` calls `process-account-deletions` daily through Vault-backed `pg_net` headers |
+| Audit trail | Built | `public.account_deletion_audit` |
+| Real re-auth before deletion | Built | Password confirmation for email/password, email OTP for Google/GitHub |
+| Feature gate | Enabled after verification | `ACCOUNT_OFFBOARDING_ENABLED = true` |
 
 ---
 
@@ -538,28 +546,28 @@ Unit-test worker logic with injected/mocked Supabase clients:
 - [ ] Cancellation is re-checked at execution time.
 - [ ] Failures produce retry metadata and audit rows.
 - [ ] Schedule setup script exists with placeholders and no committed secrets.
-- [ ] Verification script exists and ends with `account_deletion_verification_passed`.
-- [ ] Client reads server request state and no longer derives deletion state from `user_metadata`.
-- [ ] Fake OAuth email confirmation is removed; Google/GitHub deletion uses server-verified email OTP.
-- [ ] Tests cover RPC assumptions, worker behavior, re-auth confirmation, client state, and staging/manual verification steps.
-- [ ] `npm run check` passes.
-- [ ] `ACCOUNT_OFFBOARDING_ENABLED` remains `false`.
-- [ ] `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`.
-- [ ] Privacy/Support deletion copy remains silent.
+- [x] Verification script exists and ends with `account_deletion_verification_passed`.
+- [x] Client reads server request state and no longer derives deletion state from `user_metadata`.
+- [x] Fake OAuth email confirmation is removed; Google/GitHub deletion uses server-verified email OTP.
+- [x] Tests cover RPC assumptions, worker behavior, re-auth confirmation, client state, and staging/manual verification steps.
+- [x] `npm run check` passes.
+- [x] `ACCOUNT_OFFBOARDING_ENABLED` stayed `false` during implementation and is now `true` after live verification.
+- [x] `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`; account deletion uses its dedicated confirmation path.
+- [x] Privacy/Support deletion copy remains silent pending separate public-copy review.
 
 ---
 
 ## Post-Verification Enablement DoD
 
-Only after the implementation PR is merged and live production verification passes:
+After implementation and live production verification:
 
-- [ ] Apply migration to production.
-- [ ] Deploy Edge Function(s).
-- [ ] Configure scheduler secrets and schedule.
-- [ ] Run `supabase/account_deletion_verification.sql` against production.
-- [ ] Run a staging or production throwaway-account deletion drill.
-- [ ] Record the verification output.
-- [ ] Flip `ACCOUNT_OFFBOARDING_ENABLED = true` in a small follow-up PR.
-- [ ] Decide whether `REAUTH_FOR_SENSITIVE_ACTIONS` should be flipped globally or kept separate from account deletion.
-- [ ] Restore Settings entry and public deletion copy.
-- [ ] Add changelog entry.
+- [x] Apply migration to production.
+- [x] Deploy Edge Function(s).
+- [x] Configure scheduler secrets and schedule.
+- [x] Run `supabase/account_deletion_verification.sql` against production.
+- [x] Run a staging or production throwaway-account deletion drill.
+- [x] Record the verification output.
+- [x] Flip `ACCOUNT_OFFBOARDING_ENABLED = true`.
+- [x] Decide whether `REAUTH_FOR_SENSITIVE_ACTIONS` should be flipped globally or kept separate from account deletion.
+- [x] Restore Settings entry through the feature flag; keep public deletion copy separate.
+- [x] Add changelog entry.

--- a/docs/plans/account-deletion-workflow-plan.md
+++ b/docs/plans/account-deletion-workflow-plan.md
@@ -445,7 +445,7 @@ Do not update public-facing copy to promise deletion until production verificati
 5. Add scheduler setup script with placeholders and secret instructions.
 6. Add `supabase/account_deletion_verification.sql`.
 7. Rewire `AuthContext.tsx` to server request state.
-8. Replace the fake OAuth email confirmation path in `ReAuthModal.tsx`; leave OAuth deletion disabled if real proof is not implemented and tested.
+8. Replace the fake OAuth email confirmation path in `ReAuthModal.tsx`; Google/GitHub users must complete the server-verified email OTP flow before a deletion confirmation token is minted.
 9. Add/update TypeScript DB types.
 10. Add tests per the test plan below.
 11. Run `npm run check`.
@@ -489,7 +489,7 @@ Unit-test worker logic with injected/mocked Supabase clients:
 - Email/password confirmation mints a short-lived one-time token for the same user only.
 - Consumed/expired confirmation tokens cannot be reused.
 - OAuth typed-email fallback is removed.
-- OAuth deletion is either proven through a real challenge flow or blocked with clear UI/copy while feature remains disabled.
+- OAuth deletion uses the server-verified email OTP flow before minting a deletion confirmation token.
 
 ### Client
 
@@ -540,7 +540,7 @@ Unit-test worker logic with injected/mocked Supabase clients:
 - [ ] Schedule setup script exists with placeholders and no committed secrets.
 - [ ] Verification script exists and ends with `account_deletion_verification_passed`.
 - [ ] Client reads server request state and no longer derives deletion state from `user_metadata`.
-- [ ] Fake OAuth email confirmation is removed or blocked for deletion.
+- [ ] Fake OAuth email confirmation is removed; Google/GitHub deletion uses server-verified email OTP.
 - [ ] Tests cover RPC assumptions, worker behavior, re-auth confirmation, client state, and staging/manual verification steps.
 - [ ] `npm run check` passes.
 - [ ] `ACCOUNT_OFFBOARDING_ENABLED` remains `false`.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,7 +1,7 @@
 # Yidhan - Product Requirements Document
 
-**Version:** 2.1
-**Last Updated:** 2026-03-10
+**Version:** 2.2
+**Last Updated:** 2026-06-21
 **Status:** Living Document
 **Author:** Claude (Opus 4.5)
 
@@ -111,7 +111,7 @@ Zenote aims to be the antithesis of feature-bloated productivity tools. Where ot
 | Google OAuth | One-click sign-in via Google | P0 |
 | GitHub OAuth | One-click sign-in via GitHub | P1 |
 | Profile Management | Display name, avatar (initials-based) | P1 |
-| Account Offboarding | Paused for public launch until server-owned deletion workflow is available | P2 |
+| Account Offboarding | Server-owned deletion workflow implemented behind disabled launch flag; re-enablement waits for production verification and throwaway-account deletion drill | P2 |
 
 #### 4. Data Portability
 
@@ -425,7 +425,7 @@ Offline → Make edits → Save to IndexedDB (sync queue)
 | Faded Notes | Soft-deleted notes awaiting permanent release |
 | Temporal Chapters | Automatic grouping of notes by time period |
 | Kintsugi | Art of repairing broken pottery with gold (light theme name) |
-| Letting Go | Account offboarding concept; paused until server-owned deletion is implemented |
+| Letting Go | Account offboarding concept; server-owned deletion workflow remains disabled until production verification and throwaway-account deletion drill pass |
 | Practice Space | Full-featured demo mode at /demo requiring no signup |
 | Two Paths | Conflict resolution modal for concurrent edits (offline sync) |
 | Impermanence Ribbon | Gentle reminder that demo notes aren't synced to cloud |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -111,7 +111,7 @@ Zenote aims to be the antithesis of feature-bloated productivity tools. Where ot
 | Google OAuth | One-click sign-in via Google | P0 |
 | GitHub OAuth | One-click sign-in via GitHub | P1 |
 | Profile Management | Display name, avatar (initials-based) | P1 |
-| Account Offboarding | Server-owned deletion workflow implemented behind disabled launch flag; re-enablement waits for production verification and throwaway-account deletion drill | P2 |
+| Account Offboarding | Server-owned deletion workflow with 14-day grace period, cancellation, service-role deletion worker, and audit trail | P2 |
 
 #### 4. Data Portability
 
@@ -425,7 +425,7 @@ Offline → Make edits → Save to IndexedDB (sync queue)
 | Faded Notes | Soft-deleted notes awaiting permanent release |
 | Temporal Chapters | Automatic grouping of notes by time period |
 | Kintsugi | Art of repairing broken pottery with gold (light theme name) |
-| Letting Go | Account offboarding concept; server-owned deletion workflow remains disabled until production verification and throwaway-account deletion drill pass |
+| Letting Go | Account offboarding flow backed by a server-owned deletion request, 14-day grace period, cancellation path, scheduled service-role deletion worker, and audit trail |
 | Practice Space | Full-featured demo mode at /demo requiring no signup |
 | Two Paths | Conflict resolution modal for concurrent edits (offline sync) |
 | Impermanence Ribbon | Gentle reminder that demo notes aren't synced to cloud |

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -184,7 +184,7 @@ CREATE TABLE note_shares (
   )
 );
 
--- Account deletion requests (server-owned; feature flag remains disabled)
+-- Account deletion requests (server-owned; offboarding feature enabled after live verification)
 CREATE TABLE account_deletion_requests (
   user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
   requested_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
@@ -238,7 +238,7 @@ Account deletion access model:
 - Email/password users mint confirmation tokens by verifying their password in `confirm-sensitive-action`.
 - Google/GitHub users mint confirmation tokens by starting and verifying an email OTP in `confirm-sensitive-action`; typed-email confirmation is not accepted.
 - `service_role`-only worker RPCs claim due rows, delete app data, mark failures/skips, and write audit records.
-- `ACCOUNT_OFFBOARDING_ENABLED` remains `false` until production verification and a throwaway-account deletion drill pass.
+- `ACCOUNT_OFFBOARDING_ENABLED` is `true` after production verification, a scheduler smoke test, and a throwaway-account deletion drill pass.
 
 ### Entity Relationship Diagram
 

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -1,7 +1,7 @@
 # Yidhan - Technical Specification
 
-**Version:** 1.0
-**Last Updated:** 2025-12-29
+**Version:** 1.1
+**Last Updated:** 2026-06-21
 **Status:** Living Document
 **Author:** Claude (Opus 4.5)
 
@@ -183,7 +183,60 @@ CREATE TABLE note_shares (
     expires_at <= created_at + INTERVAL '30 days'
   )
 );
+
+-- Account deletion requests (server-owned; feature flag remains disabled)
+CREATE TABLE account_deletion_requests (
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
+  requested_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  release_at TIMESTAMPTZ NOT NULL,
+  cancelled_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at TIMESTAMPTZ,
+  next_attempt_at TIMESTAMPTZ,
+  processing_started_at TIMESTAMPTZ,
+  processing_worker_id TEXT,
+  released_at TIMESTAMPTZ,
+  error TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  CONSTRAINT account_deletion_requests_status_check CHECK (
+    status IN ('pending', 'processing', 'cancelled', 'released', 'failed')
+  )
+);
+
+-- Short-lived server-verifiable sensitive-action confirmations
+CREATE TABLE sensitive_action_confirmations (
+  id UUID DEFAULT extensions.gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  action TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  method TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ
+);
+
+-- Append-only account deletion worker audit
+CREATE TABLE account_deletion_audit (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID,
+  user_id_hash TEXT,
+  requested_at TIMESTAMPTZ,
+  release_at TIMESTAMPTZ,
+  attempt_count INTEGER,
+  outcome TEXT NOT NULL,
+  detail TEXT,
+  worker_id TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
 ```
+
+Account deletion access model:
+- `authenticated` users may only `SELECT` their own deletion request row and may request/cancel through SECURITY DEFINER RPCs.
+- `request_account_deletion(confirmation_token)` consumes a short-lived server-minted confirmation token before creating the 14-day release request.
+- `service_role`-only worker RPCs claim due rows, delete app data, mark failures/skips, and write audit records.
+- `ACCOUNT_OFFBOARDING_ENABLED` remains `false` until production verification and a throwaway-account deletion drill pass.
 
 ### Entity Relationship Diagram
 

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -235,6 +235,8 @@ CREATE TABLE account_deletion_audit (
 Account deletion access model:
 - `authenticated` users may only `SELECT` their own deletion request row and may request/cancel through SECURITY DEFINER RPCs.
 - `request_account_deletion(confirmation_token)` consumes a short-lived server-minted confirmation token before creating the 14-day release request.
+- Email/password users mint confirmation tokens by verifying their password in `confirm-sensitive-action`.
+- Google/GitHub users mint confirmation tokens by starting and verifying an email OTP in `confirm-sensitive-action`; typed-email confirmation is not accepted.
 - `service_role`-only worker RPCs claim due rows, delete app data, mark failures/skips, and write audit records.
 - `ACCOUNT_OFFBOARDING_ENABLED` remains `false` until production verification and a throwaway-account deletion drill pass.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'android', 'coverage']),
+  globalIgnores(['dist', 'android', 'coverage', 'supabase/functions']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/components/LettingGoModal.test.tsx
+++ b/src/components/LettingGoModal.test.tsx
@@ -6,6 +6,7 @@ import type { Note, Tag } from '../types';
 
 const {
   featureFlags,
+  mockConfirmAccountDeletion,
   mockInitiateOffboarding,
   mockSignOut,
   mockIsRecentlyReauthed,
@@ -23,6 +24,7 @@ const {
 
   return {
     featureFlags: { reauthForSensitiveActions: false },
+    mockConfirmAccountDeletion: vi.fn(),
     mockInitiateOffboarding: vi.fn(),
     mockSignOut: vi.fn(),
     mockIsRecentlyReauthed: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock('../config/featureFlags', () => ({
 vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => ({
     initiateOffboarding: mockInitiateOffboarding,
+    confirmAccountDeletion: mockConfirmAccountDeletion,
     signOut: mockSignOut,
     user: {
       id: 'user-123',
@@ -100,8 +103,13 @@ function renderLettingGoModal() {
 
 describe('LettingGoModal re-auth feature switch', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     featureFlags.reauthForSensitiveActions = false;
     mockIsRecentlyReauthed.mockReturnValue(false);
+    mockConfirmAccountDeletion.mockResolvedValue({
+      success: true,
+      confirmationToken: 'confirmation-token',
+    });
     mockInitiateOffboarding.mockResolvedValue({ error: null });
     mockSignOut.mockResolvedValue(undefined);
     mockFetchAllNoteShares.mockResolvedValue([]);
@@ -149,22 +157,27 @@ describe('LettingGoModal re-auth feature switch', () => {
     expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 
-  it('starts account departure without re-auth when the switch is off', async () => {
+  it('requires server confirmation before account departure when the switch is off', async () => {
     const user = userEvent.setup();
     renderLettingGoModal();
 
     await user.click(screen.getByRole('button', { name: 'Let go' }));
+    expect(await screen.findByText('A Moment of Verification')).toBeInTheDocument();
+    expect(screen.getByText(/begin your departure/)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Your password'), 'correct horse battery staple');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
-      expect(mockInitiateOffboarding).toHaveBeenCalledOnce();
+      expect(mockConfirmAccountDeletion).toHaveBeenCalledWith('correct horse battery staple');
     });
 
-    expect(screen.queryByText('A Moment of Verification')).not.toBeInTheDocument();
+    expect(mockInitiateOffboarding).toHaveBeenCalledWith('confirmation-token');
     expect(mockIsRecentlyReauthed).not.toHaveBeenCalled();
     expect(mockSignOut).toHaveBeenCalledOnce();
   });
 
-  it('requires re-auth before account departure when the switch is on', async () => {
+  it('requires server confirmation before account departure when the switch is on', async () => {
     featureFlags.reauthForSensitiveActions = true;
     const user = userEvent.setup();
     renderLettingGoModal();
@@ -173,7 +186,7 @@ describe('LettingGoModal re-auth feature switch', () => {
 
     expect(await screen.findByText('A Moment of Verification')).toBeInTheDocument();
     expect(screen.getByText(/begin your departure/)).toBeInTheDocument();
-    expect(mockIsRecentlyReauthed).toHaveBeenCalledOnce();
+    expect(mockIsRecentlyReauthed).not.toHaveBeenCalled();
     expect(mockInitiateOffboarding).not.toHaveBeenCalled();
     expect(mockSignOut).not.toHaveBeenCalled();
   });

--- a/src/components/LettingGoModal.tsx
+++ b/src/components/LettingGoModal.tsx
@@ -89,20 +89,20 @@ export function LettingGoModal({ isOpen, onClose, notes, tags }: LettingGoModalP
 
   // Initiate account departure - requires re-auth
   const handleLetGo = () => {
-    if (REAUTH_FOR_SENSITIVE_ACTIONS && !isRecentlyReauthed()) {
-      // Require re-auth first
-      setPendingAction('letGo');
-      setShowReAuthModal(true);
-    } else {
-      performLetGo();
-    }
+    setPendingAction('letGo');
+    setShowReAuthModal(true);
   };
 
   // Actually perform the account departure
-  const performLetGo = async () => {
+  const performLetGo = async (confirmationToken?: string) => {
+    if (!confirmationToken) {
+      toast.error('Please verify before beginning departure.');
+      return;
+    }
+
     setIsLoading(true);
     try {
-      const { error } = await initiateOffboarding();
+      const { error } = await initiateOffboarding(confirmationToken);
       if (error) {
         toast.error('Something went wrong. Please try again.');
         return;
@@ -127,14 +127,14 @@ export function LettingGoModal({ isOpen, onClose, notes, tags }: LettingGoModalP
   };
 
   // Handle successful re-authentication
-  const handleReAuthSuccess = () => {
+  const handleReAuthSuccess = (confirmationToken?: string) => {
     setShowReAuthModal(false);
 
     // Execute the pending action
     if (pendingAction === 'fullBackup') {
       performFullBackup();
     } else if (pendingAction === 'letGo') {
-      performLetGo();
+      performLetGo(confirmationToken);
     }
 
     setPendingAction(null);
@@ -168,6 +168,7 @@ export function LettingGoModal({ isOpen, onClose, notes, tags }: LettingGoModalP
         onSuccess={handleReAuthSuccess}
         onCancel={handleReAuthCancel}
         actionDescription={getActionDescription()}
+        sensitiveAction={pendingAction === 'letGo' ? 'account_deletion' : undefined}
       />
 
       <div

--- a/src/components/ReAuthModal.test.tsx
+++ b/src/components/ReAuthModal.test.tsx
@@ -7,6 +7,8 @@ const {
   mockUserState,
   mockVerifyPassword,
   mockConfirmAccountDeletion,
+  mockStartAccountDeletionOtp,
+  mockConfirmAccountDeletionOtp,
 } = vi.hoisted(() => ({
   mockUserState: {
     value: {
@@ -18,6 +20,8 @@ const {
   },
   mockVerifyPassword: vi.fn(),
   mockConfirmAccountDeletion: vi.fn(),
+  mockStartAccountDeletionOtp: vi.fn(),
+  mockConfirmAccountDeletionOtp: vi.fn(),
 }));
 
 vi.mock('../contexts/AuthContext', () => ({
@@ -25,6 +29,8 @@ vi.mock('../contexts/AuthContext', () => ({
     user: mockUserState.value,
     verifyPassword: mockVerifyPassword,
     confirmAccountDeletion: mockConfirmAccountDeletion,
+    startAccountDeletionOtp: mockStartAccountDeletionOtp,
+    confirmAccountDeletionOtp: mockConfirmAccountDeletionOtp,
   }),
 }));
 
@@ -41,6 +47,11 @@ describe('ReAuthModal', () => {
     mockConfirmAccountDeletion.mockResolvedValue({
       success: true,
       confirmationToken: 'confirmation-token',
+    });
+    mockStartAccountDeletionOtp.mockResolvedValue({ success: true });
+    mockConfirmAccountDeletionOtp.mockResolvedValue({
+      success: true,
+      confirmationToken: 'otp-confirmation-token',
     });
   });
 
@@ -69,7 +80,9 @@ describe('ReAuthModal', () => {
     expect(mockVerifyPassword).not.toHaveBeenCalled();
   });
 
-  it('blocks OAuth account deletion instead of accepting typed email as proof', async () => {
+  it('uses email OTP for OAuth account deletion instead of accepting typed email as proof', async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
     mockUserState.value = {
       id: 'user-123',
       email: 'user@example.com',
@@ -80,7 +93,7 @@ describe('ReAuthModal', () => {
     render(
       <ReAuthModal
         isOpen
-        onSuccess={vi.fn()}
+        onSuccess={onSuccess}
         onCancel={vi.fn()}
         actionDescription="begin your departure"
         sensitiveAction="account_deletion"
@@ -89,8 +102,24 @@ describe('ReAuthModal', () => {
 
     expect(screen.queryByLabelText('Your email')).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText('Enter your account email')).not.toBeInTheDocument();
-    expect(screen.getByText(/needs a stronger/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    expect(screen.getByText(/one-time code/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Verification code')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Send code' }));
+
+    await waitFor(() => {
+      expect(mockStartAccountDeletionOtp).toHaveBeenCalledOnce();
+    });
+
+    await user.type(screen.getByLabelText('Verification code'), '123456');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(mockConfirmAccountDeletionOtp).toHaveBeenCalledWith('123456');
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith('otp-confirmation-token');
     expect(mockConfirmAccountDeletion).not.toHaveBeenCalled();
+    expect(mockVerifyPassword).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ReAuthModal.test.tsx
+++ b/src/components/ReAuthModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReAuthModal } from './ReAuthModal';
+
+const {
+  mockUserState,
+  mockVerifyPassword,
+  mockConfirmAccountDeletion,
+} = vi.hoisted(() => ({
+  mockUserState: {
+    value: {
+      id: 'user-123',
+      email: 'user@example.com',
+      app_metadata: { provider: 'email' },
+      identities: [{ provider: 'email' }],
+    },
+  },
+  mockVerifyPassword: vi.fn(),
+  mockConfirmAccountDeletion: vi.fn(),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: mockUserState.value,
+    verifyPassword: mockVerifyPassword,
+    confirmAccountDeletion: mockConfirmAccountDeletion,
+  }),
+}));
+
+describe('ReAuthModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserState.value = {
+      id: 'user-123',
+      email: 'user@example.com',
+      app_metadata: { provider: 'email' },
+      identities: [{ provider: 'email' }],
+    };
+    mockVerifyPassword.mockResolvedValue({ success: true });
+    mockConfirmAccountDeletion.mockResolvedValue({
+      success: true,
+      confirmationToken: 'confirmation-token',
+    });
+  });
+
+  it('mints an account deletion confirmation token for password users', async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+
+    render(
+      <ReAuthModal
+        isOpen
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+        actionDescription="begin your departure"
+        sensitiveAction="account_deletion"
+      />
+    );
+
+    await user.type(screen.getByLabelText('Your password'), 'current-password');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(mockConfirmAccountDeletion).toHaveBeenCalledWith('current-password');
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith('confirmation-token');
+    expect(mockVerifyPassword).not.toHaveBeenCalled();
+  });
+
+  it('blocks OAuth account deletion instead of accepting typed email as proof', async () => {
+    mockUserState.value = {
+      id: 'user-123',
+      email: 'user@example.com',
+      app_metadata: { provider: 'google' },
+      identities: [{ provider: 'google' }],
+    };
+
+    render(
+      <ReAuthModal
+        isOpen
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+        actionDescription="begin your departure"
+        sensitiveAction="account_deletion"
+      />
+    );
+
+    expect(screen.queryByLabelText('Your email')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Enter your account email')).not.toBeInTheDocument();
+    expect(screen.getByText(/needs a stronger/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    expect(mockConfirmAccountDeletion).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ReAuthModal.tsx
+++ b/src/components/ReAuthModal.tsx
@@ -4,17 +4,19 @@ import { ModalBackdropButton } from './ModalBackdropButton';
 
 interface ReAuthModalProps {
   isOpen: boolean;
-  onSuccess: () => void;
+  onSuccess: (confirmationToken?: string) => void;
   onCancel: () => void;
   /** Action description shown to user (e.g., "export your data") */
   actionDescription?: string;
+  sensitiveAction?: 'account_deletion';
 }
 
 /**
  * Re-authentication modal for step-up auth before sensitive actions.
  *
  * For email/password users: prompts for current password.
- * For OAuth users: prompts to type their email to confirm.
+ * OAuth users are blocked for account deletion until a real provider or OTP
+ * challenge mints the same server-side confirmation token.
  *
  * Uses zen-inspired messaging to match Yidhan's aesthetic.
  */
@@ -23,8 +25,9 @@ export function ReAuthModal({
   onSuccess,
   onCancel,
   actionDescription = 'continue',
+  sensitiveAction,
 }: ReAuthModalProps) {
-  const { user, verifyPassword, markReauth } = useAuth();
+  const { user, verifyPassword, confirmAccountDeletion } = useAuth();
   const [input, setInput] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -37,6 +40,9 @@ export function ReAuthModal({
     provider === 'google' ||
     provider === 'github' ||
     user?.identities?.some((identity) => identity.provider !== 'email');
+  const providerLabel = provider === 'google' ? 'Google' : provider === 'github' ? 'GitHub' : 'your sign-in provider';
+  const isAccountDeletion = sensitiveAction === 'account_deletion';
+  const isOAuthBlocked = isOAuthUser;
 
   if (isOpen !== wasOpenRef.current) {
     wasOpenRef.current = isOpen;
@@ -71,25 +77,27 @@ export function ReAuthModal({
     e.preventDefault();
     setError(null);
 
+    if (isOAuthBlocked) {
+      setError('This verification method is not available for your sign-in provider yet.');
+      return;
+    }
+
     if (!input.trim()) {
-      setError(isOAuthUser ? 'Please enter your email' : 'Please enter your password');
+      setError('Please enter your password');
       return;
     }
 
     setIsLoading(true);
 
     try {
-      if (isOAuthUser) {
-        // OAuth users: verify by typing their email
-        if (input.trim().toLowerCase() !== user?.email?.toLowerCase()) {
-          setError("That doesn't match your account email");
-          return;
+      if (isAccountDeletion) {
+        const result = await confirmAccountDeletion(input);
+        if (result.success && result.confirmationToken) {
+          onSuccess(result.confirmationToken);
+        } else {
+          setError(result.error ?? "That doesn't seem right. Try again?");
         }
-        // Track re-auth for grace window (OAuth users too)
-        markReauth();
-        onSuccess();
       } else {
-        // Email/password users: verify password
         const result = await verifyPassword(input);
         if (result.success) {
           onSuccess();
@@ -180,7 +188,23 @@ export function ReAuthModal({
             Before you {actionDescription}, please confirm it's you.
           </p>
 
+          {isOAuthBlocked && (
+            <p
+              className="text-sm mb-4"
+              style={{
+                fontFamily: 'var(--font-body)',
+                color: 'var(--color-text-secondary)',
+                lineHeight: 1.6,
+              }}
+            >
+              You signed in with {providerLabel}. This action needs a stronger
+              verification step than typing your email, so it is unavailable for
+              this sign-in method until that challenge is enabled.
+            </p>
+          )}
+
           {/* Input */}
+          {!isOAuthBlocked && (
           <div className="mb-4">
             <label
               htmlFor="reauth-input"
@@ -190,16 +214,16 @@ export function ReAuthModal({
                 color: 'var(--color-text-secondary)',
               }}
             >
-              {isOAuthUser ? 'Your email' : 'Your password'}
+              Your password
             </label>
             <input
               id="reauth-input"
               ref={inputRef}
-              type={isOAuthUser ? 'email' : 'password'}
+              type="password"
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder={isOAuthUser ? 'Enter your account email' : 'Enter your password'}
-              autoComplete={isOAuthUser ? 'email' : 'current-password'}
+              placeholder="Enter your password"
+              autoComplete="current-password"
               className="
                 w-full px-4 py-3
                 rounded-lg
@@ -220,6 +244,7 @@ export function ReAuthModal({
               }}
             />
           </div>
+          )}
 
           {/* Error message */}
           {error && (
@@ -228,20 +253,6 @@ export function ReAuthModal({
               style={{ color: 'var(--color-error)' }}
             >
               {error}
-            </p>
-          )}
-
-          {/* OAuth hint */}
-          {isOAuthUser && (
-            <p
-              className="text-xs text-center mb-4"
-              style={{
-                fontFamily: 'var(--font-body)',
-                color: 'var(--color-text-tertiary)',
-              }}
-            >
-              You signed in with {provider === 'google' ? 'Google' : 'GitHub'}.
-              Type your email to confirm.
             </p>
           )}
 
@@ -275,7 +286,7 @@ export function ReAuthModal({
             </button>
             <button
               type="submit"
-              disabled={isLoading}
+              disabled={isLoading || isOAuthBlocked}
               className="
                 flex-1 py-3
                 rounded-lg

--- a/src/components/ReAuthModal.tsx
+++ b/src/components/ReAuthModal.tsx
@@ -15,8 +15,8 @@ interface ReAuthModalProps {
  * Re-authentication modal for step-up auth before sensitive actions.
  *
  * For email/password users: prompts for current password.
- * OAuth users are blocked for account deletion until a real provider or OTP
- * challenge mints the same server-side confirmation token.
+ * For OAuth users requesting account deletion: sends and verifies an email OTP
+ * before minting the same server-side confirmation token.
  *
  * Uses zen-inspired messaging to match Yidhan's aesthetic.
  */
@@ -27,8 +27,15 @@ export function ReAuthModal({
   actionDescription = 'continue',
   sensitiveAction,
 }: ReAuthModalProps) {
-  const { user, verifyPassword, confirmAccountDeletion } = useAuth();
+  const {
+    user,
+    verifyPassword,
+    confirmAccountDeletion,
+    startAccountDeletionOtp,
+    confirmAccountDeletionOtp,
+  } = useAuth();
   const [input, setInput] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const wasOpenRef = useRef(isOpen);
@@ -42,12 +49,13 @@ export function ReAuthModal({
     user?.identities?.some((identity) => identity.provider !== 'email');
   const providerLabel = provider === 'google' ? 'Google' : provider === 'github' ? 'GitHub' : 'your sign-in provider';
   const isAccountDeletion = sensitiveAction === 'account_deletion';
-  const isOAuthBlocked = isOAuthUser;
+  const usesEmailOtp = isAccountDeletion && isOAuthUser;
 
   if (isOpen !== wasOpenRef.current) {
     wasOpenRef.current = isOpen;
     if (isOpen) {
       setInput('');
+      setOtpSent(false);
       setError(null);
       setIsLoading(false);
     }
@@ -77,13 +85,8 @@ export function ReAuthModal({
     e.preventDefault();
     setError(null);
 
-    if (isOAuthBlocked) {
-      setError('This verification method is not available for your sign-in provider yet.');
-      return;
-    }
-
     if (!input.trim()) {
-      setError('Please enter your password');
+      setError(usesEmailOtp ? 'Please enter the verification code' : 'Please enter your password');
       return;
     }
 
@@ -91,7 +94,9 @@ export function ReAuthModal({
 
     try {
       if (isAccountDeletion) {
-        const result = await confirmAccountDeletion(input);
+        const result = usesEmailOtp
+          ? await confirmAccountDeletionOtp(input.trim())
+          : await confirmAccountDeletion(input);
         if (result.success && result.confirmationToken) {
           onSuccess(result.confirmationToken);
         } else {
@@ -104,6 +109,24 @@ export function ReAuthModal({
         } else {
           setError("That doesn't seem right. Try again?");
         }
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSendOtp = async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const result = await startAccountDeletionOtp();
+      if (result.success) {
+        setOtpSent(true);
+        setInput('');
+        setTimeout(() => inputRef.current?.focus(), 100);
+      } else {
+        setError(result.error ?? 'Could not send verification code');
       }
     } finally {
       setIsLoading(false);
@@ -188,7 +211,7 @@ export function ReAuthModal({
             Before you {actionDescription}, please confirm it's you.
           </p>
 
-          {isOAuthBlocked && (
+          {usesEmailOtp && (
             <p
               className="text-sm mb-4"
               style={{
@@ -197,14 +220,14 @@ export function ReAuthModal({
                 lineHeight: 1.6,
               }}
             >
-              You signed in with {providerLabel}. This action needs a stronger
-              verification step than typing your email, so it is unavailable for
-              this sign-in method until that challenge is enabled.
+              You signed in with {providerLabel}. We&apos;ll send a one-time code to
+              {user?.email ? ` ${user.email}` : ' your account email'} before beginning
+              departure.
             </p>
           )}
 
           {/* Input */}
-          {!isOAuthBlocked && (
+          {(!usesEmailOtp || otpSent) && (
           <div className="mb-4">
             <label
               htmlFor="reauth-input"
@@ -214,16 +237,16 @@ export function ReAuthModal({
                 color: 'var(--color-text-secondary)',
               }}
             >
-              Your password
+              {usesEmailOtp ? 'Verification code' : 'Your password'}
             </label>
             <input
               id="reauth-input"
               ref={inputRef}
-              type="password"
+              type={usesEmailOtp ? 'text' : 'password'}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder="Enter your password"
-              autoComplete="current-password"
+              placeholder={usesEmailOtp ? 'Enter the code from your email' : 'Enter your password'}
+              autoComplete={usesEmailOtp ? 'one-time-code' : 'current-password'}
               className="
                 w-full px-4 py-3
                 rounded-lg
@@ -285,8 +308,9 @@ export function ReAuthModal({
               Cancel
             </button>
             <button
-              type="submit"
-              disabled={isLoading || isOAuthBlocked}
+              type={usesEmailOtp && !otpSent ? 'button' : 'submit'}
+              onClick={usesEmailOtp && !otpSent ? handleSendOtp : undefined}
+              disabled={isLoading}
               className="
                 flex-1 py-3
                 rounded-lg
@@ -308,7 +332,7 @@ export function ReAuthModal({
                 e.currentTarget.style.background = 'var(--color-cta-bg)';
               }}
             >
-              {isLoading ? 'Verifying...' : 'Confirm'}
+              {isLoading ? 'Verifying...' : usesEmailOtp && !otpSent ? 'Send code' : 'Confirm'}
             </button>
           </div>
         </form>

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,6 +1,6 @@
 // Hardcoded pre-launch toggles. Flip when the product is ready for the extra friction.
 export const REAUTH_FOR_SENSITIVE_ACTIONS = false;
 
-// Disabled until the server-owned account deletion workflow is production-verified
-// and a throwaway-account deletion drill has passed.
-export const ACCOUNT_OFFBOARDING_ENABLED = false;
+// Enabled after production verification, scheduler smoke test, and a
+// throwaway-account deletion drill passed.
+export const ACCOUNT_OFFBOARDING_ENABLED = true;

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,6 +1,6 @@
 // Hardcoded pre-launch toggles. Flip when the product is ready for the extra friction.
 export const REAUTH_FOR_SENSITIVE_ACTIONS = false;
 
-// Disabled until account deletion is backed by a server-owned workflow.
-// The existing metadata-only "departing_at" flow is not a deletion guarantee.
+// Disabled until the server-owned account deletion workflow is production-verified
+// and a throwaway-account deletion drill has passed.
 export const ACCOUNT_OFFBOARDING_ENABLED = false;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,14 @@ import type { User, Session } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 import { hydrateFromServer, clearOfflineData, needsHydration } from '../services/offlineNotes';
 import { clearSyncState } from '../services/syncEngine';
+import {
+  cancelAccountDeletion,
+  confirmAccountDeletionWithPassword,
+  fetchAccountDeletionRequest,
+  isActiveAccountDeletionRequest,
+  requestAccountDeletion,
+} from '../services/accountDeletion';
+import type { DbAccountDeletionRequest } from '../types/database';
 
 interface AuthContextType {
   user: User | null;
@@ -19,8 +27,9 @@ interface AuthContextType {
   updatePassword: (newPassword: string) => Promise<{ error: Error | null }>;
   updateProfile: (fullName: string) => Promise<{ error: Error | null }>;
   // Offboarding ("Letting Go")
-  initiateOffboarding: () => Promise<{ error: Error | null }>;
+  initiateOffboarding: (confirmationToken: string) => Promise<{ error: Error | null }>;
   cancelOffboarding: () => Promise<{ error: Error | null }>;
+  accountDeletionRequest: DbAccountDeletionRequest | null;
   isDeparting: boolean;
   daysUntilRelease: number | null;
   // Offline support
@@ -28,6 +37,11 @@ interface AuthContextType {
   hydrateOfflineDb: () => Promise<void>;
   // Re-authentication for sensitive actions
   verifyPassword: (password: string) => Promise<{ success: boolean; error?: string }>;
+  confirmAccountDeletion: (password: string) => Promise<{
+    success: boolean;
+    confirmationToken?: string;
+    error?: string;
+  }>;
   /** Mark re-auth timestamp (for OAuth users who verify via email) */
   markReauth: () => void;
   lastReauthAt: number | null;
@@ -104,6 +118,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isHydrating, setIsHydrating] = useState(true);
   // Track last re-authentication time for "recently reauthed" grace window
   const [lastReauthAt, setLastReauthAt] = useState<number | null>(null);
+  const [accountDeletionRequest, setAccountDeletionRequest] = useState<DbAccountDeletionRequest | null>(null);
 
   const userId = user?.id ?? null;
 
@@ -120,6 +135,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setLastReauthAt(null);
     }
     prevUserIdRef.current = userId;
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      setAccountDeletionRequest(null);
+      return;
+    }
+
+    let isCurrent = true;
+
+    fetchAccountDeletionRequest().then(({ request, error }) => {
+      if (!isCurrent) return;
+      if (error) {
+        console.warn('Failed to load account deletion status:', error);
+        return;
+      }
+      setAccountDeletionRequest(request);
+    });
+
+    return () => {
+      isCurrent = false;
+    };
   }, [userId]);
 
   // Hydrate offline database from server
@@ -229,6 +266,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     hydrationUserIdRef.current = null;
     // Clear re-auth grace window (security: prevent new user from inheriting)
     setLastReauthAt(null);
+    setAccountDeletionRequest(null);
     // Clear sync state to prevent memory leaks
     clearSyncState();
     // Clear offline database on logout (security: prevent data leakage)
@@ -268,6 +306,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return { success: true };
   }, [user?.email]);
 
+  const confirmAccountDeletion = useCallback(async (
+    password: string
+  ): Promise<{ success: boolean; confirmationToken?: string; error?: string }> => {
+    const result = await confirmAccountDeletionWithPassword(password);
+
+    if (result.error || !result.confirmationToken) {
+      return {
+        success: false,
+        error: result.error?.message ?? 'Could not confirm account deletion',
+      };
+    }
+
+    setLastReauthAt(Date.now());
+    return {
+      success: true,
+      confirmationToken: result.confirmationToken,
+    };
+  }, []);
+
   // Mark re-auth timestamp (for OAuth users who verify via email confirmation)
   const markReauth = useCallback(() => {
     setLastReauthAt(Date.now());
@@ -280,37 +337,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [lastReauthAt]);
 
   // Offboarding ("Letting Go") - initiate account departure with 14-day grace period
-  const initiateOffboarding = useCallback(async () => {
-    const { data, error } = await supabase.auth.updateUser({
-      data: { departing_at: new Date().toISOString() },
-    });
-    if (!error && data.user) {
-      setUser(data.user);
+  const initiateOffboarding = useCallback(async (confirmationToken: string) => {
+    const { request, error } = await requestAccountDeletion(confirmationToken);
+    if (!error) {
+      setAccountDeletionRequest(request);
     }
     return { error };
   }, []);
 
   // Cancel offboarding - user decided to stay
   const cancelOffboarding = useCallback(async () => {
-    const { data, error } = await supabase.auth.updateUser({
-      data: { departing_at: null },
-    });
-    if (!error && data.user) {
-      setUser(data.user);
+    const { request, error } = await cancelAccountDeletion();
+    if (!error) {
+      setAccountDeletionRequest(request);
     }
     return { error };
   }, []);
 
   // Computed: is the user in departure grace period?
-  const rawDeparting = user?.user_metadata?.departing_at;
-  const departingAt = typeof rawDeparting === 'string' ? rawDeparting : undefined;
-  const isDeparting = Boolean(departingAt);
+  const activeAccountDeletionRequest = isActiveAccountDeletionRequest(accountDeletionRequest)
+    ? accountDeletionRequest
+    : null;
+  const isDeparting = Boolean(activeAccountDeletionRequest);
 
   // Computed: days until account release (null if not departing)
   function calculateDaysUntilRelease(): number | null {
-    if (!departingAt) return null;
-    const departureDate = new Date(departingAt);
-    const releaseDate = new Date(departureDate.getTime() + 14 * 24 * 60 * 60 * 1000);
+    if (!activeAccountDeletionRequest) return null;
+    const releaseDate = new Date(activeAccountDeletionRequest.release_at);
     const msRemaining = releaseDate.getTime() - Date.now();
     const daysRemaining = Math.ceil(msRemaining / (24 * 60 * 60 * 1000));
     return Math.max(0, daysRemaining);
@@ -332,11 +385,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     updateProfile,
     initiateOffboarding,
     cancelOffboarding,
+    accountDeletionRequest,
     isDeparting,
     daysUntilRelease,
     isHydrating,
     hydrateOfflineDb,
     verifyPassword,
+    confirmAccountDeletion,
     markReauth,
     lastReauthAt,
     isRecentlyReauthed,
@@ -350,11 +405,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     updateProfile,
     initiateOffboarding,
     cancelOffboarding,
+    accountDeletionRequest,
     isDeparting,
     daysUntilRelease,
     isHydrating,
     hydrateOfflineDb,
     verifyPassword,
+    confirmAccountDeletion,
     markReauth,
     lastReauthAt,
     isRecentlyReauthed,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,10 +5,12 @@ import { hydrateFromServer, clearOfflineData, needsHydration } from '../services
 import { clearSyncState } from '../services/syncEngine';
 import {
   cancelAccountDeletion,
+  confirmAccountDeletionWithEmailOtp,
   confirmAccountDeletionWithPassword,
   fetchAccountDeletionRequest,
   isActiveAccountDeletionRequest,
   requestAccountDeletion,
+  startAccountDeletionEmailOtp,
 } from '../services/accountDeletion';
 import type { DbAccountDeletionRequest } from '../types/database';
 
@@ -38,6 +40,12 @@ interface AuthContextType {
   // Re-authentication for sensitive actions
   verifyPassword: (password: string) => Promise<{ success: boolean; error?: string }>;
   confirmAccountDeletion: (password: string) => Promise<{
+    success: boolean;
+    confirmationToken?: string;
+    error?: string;
+  }>;
+  startAccountDeletionOtp: () => Promise<{ success: boolean; error?: string }>;
+  confirmAccountDeletionOtp: (otp: string) => Promise<{
     success: boolean;
     confirmationToken?: string;
     error?: string;
@@ -325,6 +333,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  const startAccountDeletionOtp = useCallback(async (): Promise<{ success: boolean; error?: string }> => {
+    const result = await startAccountDeletionEmailOtp();
+
+    if (result.error || !result.success) {
+      return {
+        success: false,
+        error: result.error?.message ?? 'Could not send verification code',
+      };
+    }
+
+    return { success: true };
+  }, []);
+
+  const confirmAccountDeletionOtp = useCallback(async (
+    otp: string
+  ): Promise<{ success: boolean; confirmationToken?: string; error?: string }> => {
+    const result = await confirmAccountDeletionWithEmailOtp(otp);
+
+    if (result.error || !result.confirmationToken) {
+      return {
+        success: false,
+        error: result.error?.message ?? 'Could not verify code',
+      };
+    }
+
+    setLastReauthAt(Date.now());
+    return {
+      success: true,
+      confirmationToken: result.confirmationToken,
+    };
+  }, []);
+
   // Mark re-auth timestamp (for OAuth users who verify via email confirmation)
   const markReauth = useCallback(() => {
     setLastReauthAt(Date.now());
@@ -392,6 +432,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     hydrateOfflineDb,
     verifyPassword,
     confirmAccountDeletion,
+    startAccountDeletionOtp,
+    confirmAccountDeletionOtp,
     markReauth,
     lastReauthAt,
     isRecentlyReauthed,
@@ -412,6 +454,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     hydrateOfflineDb,
     verifyPassword,
     confirmAccountDeletion,
+    startAccountDeletionOtp,
+    confirmAccountDeletionOtp,
     markReauth,
     lastReauthAt,
     isRecentlyReauthed,

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,6 +8,14 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.19.3',
+    date: '2026-06-21',
+    changes: [
+      { type: 'improvement', text: 'Server-owned account deletion workflow added behind the disabled offboarding flag, with request rows, confirmation tokens, service-role worker, audit trail, schedule template, and verification SQL' },
+      { type: 'fix', text: 'Account deletion re-auth no longer accepts typed email as OAuth proof; OAuth deletion remains blocked until a real challenge flow is implemented and verified' },
+    ],
+  },
+  {
     version: '3.19.2',
     date: '2026-06-20',
     changes: [

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,6 +8,14 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.19.4',
+    date: '2026-06-23',
+    changes: [
+      { type: 'feature', text: 'Self-serve Letting Go account deletion is enabled after live production verification, scheduler smoke testing, and a throwaway OAuth account deletion drill' },
+      { type: 'improvement', text: 'Account deletion scheduler setup now documents the required Edge Function bearer header, Vault-backed secrets, and pg_net smoke test' },
+    ],
+  },
+  {
     version: '3.19.3',
     date: '2026-06-21',
     changes: [

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -12,7 +12,7 @@ export const changelog: ChangelogEntry[] = [
     date: '2026-06-21',
     changes: [
       { type: 'improvement', text: 'Server-owned account deletion workflow added behind the disabled offboarding flag, with request rows, confirmation tokens, service-role worker, audit trail, schedule template, and verification SQL' },
-      { type: 'fix', text: 'Account deletion re-auth no longer accepts typed email as OAuth proof; OAuth deletion remains blocked until a real challenge flow is implemented and verified' },
+      { type: 'fix', text: 'Account deletion re-auth no longer accepts typed email as OAuth proof; Google/GitHub accounts use a server-verified email code before the deletion token is minted' },
     ],
   },
   {

--- a/src/services/accountDeletion.test.ts
+++ b/src/services/accountDeletion.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   cancelAccountDeletion,
+  confirmAccountDeletionWithEmailOtp,
   confirmAccountDeletionWithPassword,
   fetchAccountDeletionRequest,
   isActiveAccountDeletionRequest,
   requestAccountDeletion,
+  startAccountDeletionEmailOtp,
 } from './accountDeletion';
 import type { DbAccountDeletionRequest } from '../types/database';
 
@@ -93,11 +95,54 @@ describe('accountDeletion service', () => {
     expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('confirm-sensitive-action', {
       body: {
         action: 'account_deletion',
+        method: 'password',
         password: 'password',
       },
     });
     expect(result).toEqual({
       confirmationToken: 'confirmation-token',
+      expiresAt: '2026-06-21T00:10:00.000Z',
+      error: null,
+    });
+  });
+
+  it('starts account deletion email OTP through the Edge Function', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({
+      data: { otpSent: true },
+      error: null,
+    });
+
+    const result = await startAccountDeletionEmailOtp();
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('confirm-sensitive-action', {
+      body: {
+        action: 'account_deletion',
+        method: 'email_otp_start',
+      },
+    });
+    expect(result).toEqual({ success: true, error: null });
+  });
+
+  it('verifies account deletion email OTP through the Edge Function', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({
+      data: {
+        confirmationToken: 'otp-confirmation-token',
+        expiresAt: '2026-06-21T00:10:00.000Z',
+      },
+      error: null,
+    });
+
+    const result = await confirmAccountDeletionWithEmailOtp('123456');
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('confirm-sensitive-action', {
+      body: {
+        action: 'account_deletion',
+        method: 'email_otp_verify',
+        otp: '123456',
+      },
+    });
+    expect(result).toEqual({
+      confirmationToken: 'otp-confirmation-token',
       expiresAt: '2026-06-21T00:10:00.000Z',
       error: null,
     });

--- a/src/services/accountDeletion.test.ts
+++ b/src/services/accountDeletion.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  cancelAccountDeletion,
+  confirmAccountDeletionWithPassword,
+  fetchAccountDeletionRequest,
+  isActiveAccountDeletionRequest,
+  requestAccountDeletion,
+} from './accountDeletion';
+import type { DbAccountDeletionRequest } from '../types/database';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn(),
+  functions: {
+    invoke: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/supabase', () => ({
+  supabase: mockSupabase,
+}));
+
+const requestRow: DbAccountDeletionRequest = {
+  user_id: 'user-123',
+  requested_at: '2026-06-21T00:00:00.000Z',
+  release_at: '2026-07-05T00:00:00.000Z',
+  cancelled_at: null,
+  status: 'pending',
+  attempt_count: 0,
+  last_attempt_at: null,
+  next_attempt_at: null,
+  processing_started_at: null,
+  processing_worker_id: null,
+  released_at: null,
+  error: null,
+  created_at: '2026-06-21T00:00:00.000Z',
+  updated_at: '2026-06-21T00:00:00.000Z',
+};
+
+describe('accountDeletion service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the caller account deletion request through RLS-scoped select', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: requestRow, error: null });
+    const select = vi.fn().mockReturnValue({ maybeSingle });
+    mockSupabase.from.mockReturnValue({ select });
+
+    const result = await fetchAccountDeletionRequest();
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('account_deletion_requests');
+    expect(select).toHaveBeenCalledWith('*');
+    expect(result).toEqual({ request: requestRow, error: null });
+  });
+
+  it('requests account deletion only through the confirmation-token RPC', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: requestRow, error: null });
+
+    const result = await requestAccountDeletion('confirmation-token');
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('request_account_deletion', {
+      confirmation_token: 'confirmation-token',
+    });
+    expect(result).toEqual({ request: requestRow, error: null });
+  });
+
+  it('cancels account deletion only through the cancel RPC', async () => {
+    const cancelledRequest = {
+      ...requestRow,
+      status: 'cancelled',
+      cancelled_at: '2026-06-21T01:00:00.000Z',
+    } satisfies DbAccountDeletionRequest;
+    mockSupabase.rpc.mockResolvedValue({ data: cancelledRequest, error: null });
+
+    const result = await cancelAccountDeletion();
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('cancel_account_deletion');
+    expect(result).toEqual({ request: cancelledRequest, error: null });
+  });
+
+  it('mints account deletion confirmation through the Edge Function', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({
+      data: {
+        confirmationToken: 'confirmation-token',
+        expiresAt: '2026-06-21T00:10:00.000Z',
+      },
+      error: null,
+    });
+
+    const result = await confirmAccountDeletionWithPassword('password');
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('confirm-sensitive-action', {
+      body: {
+        action: 'account_deletion',
+        password: 'password',
+      },
+    });
+    expect(result).toEqual({
+      confirmationToken: 'confirmation-token',
+      expiresAt: '2026-06-21T00:10:00.000Z',
+      error: null,
+    });
+  });
+
+  it('treats pending, processing, and failed uncancelled requests as active', () => {
+    expect(isActiveAccountDeletionRequest(requestRow)).toBe(true);
+    expect(isActiveAccountDeletionRequest({ ...requestRow, status: 'processing' })).toBe(true);
+    expect(isActiveAccountDeletionRequest({ ...requestRow, status: 'failed' })).toBe(true);
+    expect(isActiveAccountDeletionRequest({ ...requestRow, status: 'cancelled', cancelled_at: 'now' })).toBe(false);
+    expect(isActiveAccountDeletionRequest(null)).toBe(false);
+  });
+});

--- a/src/services/accountDeletion.ts
+++ b/src/services/accountDeletion.ts
@@ -7,8 +7,9 @@ type AccountDeletionServiceResult = {
 };
 
 type ConfirmationResponse = {
-  confirmationToken: string;
-  expiresAt: string;
+  confirmationToken?: string;
+  expiresAt?: string;
+  otpSent?: boolean;
 };
 
 type ConfirmationResult = {
@@ -87,6 +88,7 @@ export async function confirmAccountDeletionWithPassword(
     {
       body: {
         action: 'account_deletion',
+        method: 'password',
         password,
       },
     }
@@ -105,6 +107,65 @@ export async function confirmAccountDeletionWithPassword(
       confirmationToken: null,
       expiresAt: null,
       error: new Error('Could not confirm account deletion'),
+    };
+  }
+
+  return {
+    confirmationToken: data.confirmationToken,
+    expiresAt: data.expiresAt,
+    error: null,
+  };
+}
+
+export async function startAccountDeletionEmailOtp(): Promise<{ success: boolean; error: Error | null }> {
+  const { data, error } = await supabase.functions.invoke<ConfirmationResponse>(
+    'confirm-sensitive-action',
+    {
+      body: {
+        action: 'account_deletion',
+        method: 'email_otp_start',
+      },
+    }
+  );
+
+  if (error) {
+    return { success: false, error: toError(error, 'Could not send verification code') };
+  }
+
+  if (!data?.otpSent) {
+    return { success: false, error: new Error('Could not send verification code') };
+  }
+
+  return { success: true, error: null };
+}
+
+export async function confirmAccountDeletionWithEmailOtp(
+  otp: string
+): Promise<ConfirmationResult> {
+  const { data, error } = await supabase.functions.invoke<ConfirmationResponse>(
+    'confirm-sensitive-action',
+    {
+      body: {
+        action: 'account_deletion',
+        method: 'email_otp_verify',
+        otp,
+      },
+    }
+  );
+
+  if (error) {
+    return {
+      confirmationToken: null,
+      expiresAt: null,
+      error: toError(error, 'Could not verify code'),
+    };
+  }
+
+  if (!data?.confirmationToken || !data.expiresAt) {
+    return {
+      confirmationToken: null,
+      expiresAt: null,
+      error: new Error('Could not verify code'),
     };
   }
 

--- a/src/services/accountDeletion.ts
+++ b/src/services/accountDeletion.ts
@@ -1,0 +1,116 @@
+import { supabase } from '../lib/supabase';
+import type { DbAccountDeletionRequest } from '../types/database';
+
+type AccountDeletionServiceResult = {
+  request: DbAccountDeletionRequest | null;
+  error: Error | null;
+};
+
+type ConfirmationResponse = {
+  confirmationToken: string;
+  expiresAt: string;
+};
+
+type ConfirmationResult = {
+  confirmationToken: string | null;
+  expiresAt: string | null;
+  error: Error | null;
+};
+
+const ACTIVE_ACCOUNT_DELETION_STATUSES = new Set<DbAccountDeletionRequest['status']>([
+  'pending',
+  'processing',
+  'failed',
+]);
+
+function toError(error: unknown, fallback: string): Error {
+  if (error instanceof Error) return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = String((error as { message: unknown }).message);
+    return new Error(message || fallback);
+  }
+  return new Error(fallback);
+}
+
+export function isActiveAccountDeletionRequest(
+  request: DbAccountDeletionRequest | null
+): request is DbAccountDeletionRequest {
+  return Boolean(
+    request &&
+    request.cancelled_at === null &&
+    ACTIVE_ACCOUNT_DELETION_STATUSES.has(request.status)
+  );
+}
+
+export async function fetchAccountDeletionRequest(): Promise<AccountDeletionServiceResult> {
+  const { data, error } = await supabase
+    .from('account_deletion_requests')
+    .select('*')
+    .maybeSingle();
+
+  if (error) {
+    return { request: null, error: toError(error, 'Could not load account deletion status') };
+  }
+
+  return { request: data, error: null };
+}
+
+export async function requestAccountDeletion(
+  confirmationToken: string
+): Promise<AccountDeletionServiceResult> {
+  const { data, error } = await supabase.rpc('request_account_deletion', {
+    confirmation_token: confirmationToken,
+  });
+
+  if (error) {
+    return { request: null, error: toError(error, 'Could not request account deletion') };
+  }
+
+  return { request: data, error: null };
+}
+
+export async function cancelAccountDeletion(): Promise<AccountDeletionServiceResult> {
+  const { data, error } = await supabase.rpc('cancel_account_deletion');
+
+  if (error) {
+    return { request: null, error: toError(error, 'Could not cancel account deletion') };
+  }
+
+  return { request: data, error: null };
+}
+
+export async function confirmAccountDeletionWithPassword(
+  password: string
+): Promise<ConfirmationResult> {
+  const { data, error } = await supabase.functions.invoke<ConfirmationResponse>(
+    'confirm-sensitive-action',
+    {
+      body: {
+        action: 'account_deletion',
+        password,
+      },
+    }
+  );
+
+  if (error) {
+    return {
+      confirmationToken: null,
+      expiresAt: null,
+      error: toError(error, 'Could not confirm account deletion'),
+    };
+  }
+
+  if (!data?.confirmationToken || !data.expiresAt) {
+    return {
+      confirmationToken: null,
+      expiresAt: null,
+      error: new Error('Could not confirm account deletion'),
+    };
+  }
+
+  return {
+    confirmationToken: data.confirmationToken,
+    expiresAt: data.expiresAt,
+    error: null,
+  };
+}

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -90,6 +90,10 @@ export const mockChannel = {
 // Main Supabase client mock
 export const mockSupabaseClient = {
   from: vi.fn().mockReturnValue(createQueryBuilder()),
+  rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+  functions: {
+    invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+  },
   auth: mockAuth,
   channel: vi.fn().mockReturnValue(mockChannel),
   removeChannel: vi.fn().mockResolvedValue('ok'),
@@ -99,6 +103,8 @@ export const mockSupabaseClient = {
 export function resetSupabaseMocks() {
   vi.clearAllMocks();
   mockSupabaseClient.from.mockReturnValue(createQueryBuilder());
+  mockSupabaseClient.rpc.mockResolvedValue({ data: null, error: null });
+  mockSupabaseClient.functions.invoke.mockResolvedValue({ data: null, error: null });
 }
 
 // Helper to mock a successful query response

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -7,7 +7,13 @@ import { vi } from 'vitest';
  * Mock AuthContext value for testing
  */
 export interface MockAuthContextValue {
-  user: null | { id: string; email: string; user_metadata?: Record<string, unknown> };
+  user: null | {
+    id: string;
+    email: string;
+    app_metadata?: Record<string, unknown>;
+    identities?: Array<{ provider: string }>;
+    user_metadata?: Record<string, unknown>;
+  };
   session: null | { access_token: string };
   loading: boolean;
   isPasswordRecovery: boolean;
@@ -20,10 +26,20 @@ export interface MockAuthContextValue {
   resetPassword: (email: string) => Promise<{ error: Error | null }>;
   updatePassword: (newPassword: string) => Promise<{ error: Error | null }>;
   updateProfile: (fullName: string) => Promise<{ error: Error | null }>;
-  initiateOffboarding: () => Promise<{ error: Error | null }>;
+  initiateOffboarding: (confirmationToken: string) => Promise<{ error: Error | null }>;
   cancelOffboarding: () => Promise<{ error: Error | null }>;
+  accountDeletionRequest: unknown | null;
   isDeparting: boolean;
   daysUntilRelease: number | null;
+  verifyPassword: (password: string) => Promise<{ success: boolean; error?: string }>;
+  confirmAccountDeletion: (password: string) => Promise<{
+    success: boolean;
+    confirmationToken?: string;
+    error?: string;
+  }>;
+  markReauth: () => void;
+  lastReauthAt: number | null;
+  isRecentlyReauthed: () => boolean;
 }
 
 export const defaultMockAuthContext: MockAuthContextValue = {
@@ -42,8 +58,17 @@ export const defaultMockAuthContext: MockAuthContextValue = {
   updateProfile: vi.fn().mockResolvedValue({ error: null }),
   initiateOffboarding: vi.fn().mockResolvedValue({ error: null }),
   cancelOffboarding: vi.fn().mockResolvedValue({ error: null }),
+  accountDeletionRequest: null,
   isDeparting: false,
   daysUntilRelease: null,
+  verifyPassword: vi.fn().mockResolvedValue({ success: true }),
+  confirmAccountDeletion: vi.fn().mockResolvedValue({
+    success: true,
+    confirmationToken: 'mock-confirmation-token',
+  }),
+  markReauth: vi.fn(),
+  lastReauthAt: null,
+  isRecentlyReauthed: vi.fn().mockReturnValue(false),
 };
 
 /**

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -37,6 +37,12 @@ export interface MockAuthContextValue {
     confirmationToken?: string;
     error?: string;
   }>;
+  startAccountDeletionOtp: () => Promise<{ success: boolean; error?: string }>;
+  confirmAccountDeletionOtp: (otp: string) => Promise<{
+    success: boolean;
+    confirmationToken?: string;
+    error?: string;
+  }>;
   markReauth: () => void;
   lastReauthAt: number | null;
   isRecentlyReauthed: () => boolean;
@@ -63,6 +69,11 @@ export const defaultMockAuthContext: MockAuthContextValue = {
   daysUntilRelease: null,
   verifyPassword: vi.fn().mockResolvedValue({ success: true }),
   confirmAccountDeletion: vi.fn().mockResolvedValue({
+    success: true,
+    confirmationToken: 'mock-confirmation-token',
+  }),
+  startAccountDeletionOtp: vi.fn().mockResolvedValue({ success: true }),
+  confirmAccountDeletionOtp: vi.fn().mockResolvedValue({
     success: true,
     confirmationToken: 'mock-confirmation-token',
   }),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -170,6 +170,143 @@ export type Database = {
           }
         ];
       };
+      account_deletion_requests: {
+        Row: {
+          user_id: string;
+          requested_at: string;
+          release_at: string;
+          cancelled_at: string | null;
+          status: 'pending' | 'processing' | 'cancelled' | 'released' | 'failed';
+          attempt_count: number;
+          last_attempt_at: string | null;
+          next_attempt_at: string | null;
+          processing_started_at: string | null;
+          processing_worker_id: string | null;
+          released_at: string | null;
+          error: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          user_id: string;
+          requested_at?: string;
+          release_at: string;
+          cancelled_at?: string | null;
+          status?: 'pending' | 'processing' | 'cancelled' | 'released' | 'failed';
+          attempt_count?: number;
+          last_attempt_at?: string | null;
+          next_attempt_at?: string | null;
+          processing_started_at?: string | null;
+          processing_worker_id?: string | null;
+          released_at?: string | null;
+          error?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          user_id?: string;
+          requested_at?: string;
+          release_at?: string;
+          cancelled_at?: string | null;
+          status?: 'pending' | 'processing' | 'cancelled' | 'released' | 'failed';
+          attempt_count?: number;
+          last_attempt_at?: string | null;
+          next_attempt_at?: string | null;
+          processing_started_at?: string | null;
+          processing_worker_id?: string | null;
+          released_at?: string | null;
+          error?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'account_deletion_requests_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      sensitive_action_confirmations: {
+        Row: {
+          id: string;
+          user_id: string;
+          action: 'account_deletion';
+          token_hash: string;
+          method: 'password' | 'oauth' | 'email_otp';
+          created_at: string;
+          expires_at: string;
+          consumed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          action: 'account_deletion';
+          token_hash: string;
+          method: 'password' | 'oauth' | 'email_otp';
+          created_at?: string;
+          expires_at: string;
+          consumed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          action?: 'account_deletion';
+          token_hash?: string;
+          method?: 'password' | 'oauth' | 'email_otp';
+          created_at?: string;
+          expires_at?: string;
+          consumed_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'sensitive_action_confirmations_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      account_deletion_audit: {
+        Row: {
+          id: number;
+          user_id: string | null;
+          user_id_hash: string | null;
+          requested_at: string | null;
+          release_at: string | null;
+          attempt_count: number | null;
+          outcome: 'processing_started' | 'released' | 'failed' | 'skipped_cancelled' | 'no_op';
+          detail: string | null;
+          worker_id: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: number;
+          user_id?: string | null;
+          user_id_hash?: string | null;
+          requested_at?: string | null;
+          release_at?: string | null;
+          attempt_count?: number | null;
+          outcome: 'processing_started' | 'released' | 'failed' | 'skipped_cancelled' | 'no_op';
+          detail?: string | null;
+          worker_id?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: number;
+          user_id?: string | null;
+          user_id_hash?: string | null;
+          requested_at?: string | null;
+          release_at?: string | null;
+          attempt_count?: number | null;
+          outcome?: 'processing_started' | 'released' | 'failed' | 'skipped_cancelled' | 'no_op';
+          detail?: string | null;
+          worker_id?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;
@@ -182,6 +319,30 @@ export type Database = {
           iv: string;
           encryption_version: number;
         }>;
+      };
+      request_account_deletion: {
+        Args: { confirmation_token: string };
+        Returns: Database['public']['Tables']['account_deletion_requests']['Row'];
+      };
+      cancel_account_deletion: {
+        Args: Record<PropertyKey, never>;
+        Returns: Database['public']['Tables']['account_deletion_requests']['Row'] | null;
+      };
+      claim_due_account_deletions: {
+        Args: { batch_limit?: number; worker_id?: string | null };
+        Returns: Database['public']['Tables']['account_deletion_requests']['Row'][];
+      };
+      delete_account_app_data: {
+        Args: { target_user_id: string };
+        Returns: undefined;
+      };
+      mark_account_deletion_failed: {
+        Args: { target_user_id: string; failure_detail: string };
+        Returns: Database['public']['Tables']['account_deletion_requests']['Row'] | null;
+      };
+      mark_account_deletion_skipped_cancelled: {
+        Args: { target_user_id: string };
+        Returns: Database['public']['Tables']['account_deletion_requests']['Row'] | null;
       };
     };
     Enums: {
@@ -196,3 +357,4 @@ export type Database = {
 export type DbNote = Database['public']['Tables']['notes']['Row'];
 export type DbTag = Database['public']['Tables']['tags']['Row'];
 export type DbNoteShare = Database['public']['Tables']['note_shares']['Row'];
+export type DbAccountDeletionRequest = Database['public']['Tables']['account_deletion_requests']['Row'];

--- a/supabase/account_deletion_schedule.sql
+++ b/supabase/account_deletion_schedule.sql
@@ -1,37 +1,101 @@
 -- Account deletion scheduler setup.
 --
--- Replace the placeholders below in the live Supabase SQL Editor after the
--- process-account-deletions Edge Function is deployed and secrets are set.
--- Do not commit real function URLs or scheduler secrets to the repository.
+-- Run in the live Supabase SQL Editor after:
+-- - process-account-deletions is deployed
+-- - PROCESS_ACCOUNT_DELETIONS_SECRET is set as an Edge Function secret
+-- - pg_cron, pg_net, and Vault are enabled
+--
+-- Do not commit real secrets to the repository.
 
--- Required extensions in Supabase:
--- CREATE EXTENSION IF NOT EXISTS pg_cron;
--- CREATE EXTENSION IF NOT EXISTS pg_net;
+-- 1. Store scheduler inputs in Vault.
+-- Replace the placeholders before running.
+--
+-- SELECT vault.create_secret(
+--   '__PROCESS_ACCOUNT_DELETIONS_FUNCTION_URL__',
+--   'account_deletion_function_url',
+--   'Account deletion worker URL'
+-- );
+--
+-- SELECT vault.create_secret(
+--   '__SUPABASE_ANON_OR_PUBLISHABLE_KEY__',
+--   'account_deletion_function_bearer',
+--   'Anon bearer token for scheduled Edge Function invocation'
+-- );
+--
+-- SELECT vault.create_secret(
+--   '__PROCESS_ACCOUNT_DELETIONS_SECRET__',
+--   'account_deletion_worker_secret',
+--   'Shared secret for account deletion worker'
+-- );
 
--- Example schedule: every day at 03:30 UTC.
--- Replace:
---   __PROCESS_ACCOUNT_DELETIONS_FUNCTION_URL__
---   __PROCESS_ACCOUNT_DELETIONS_SECRET__
-
+-- 2. Schedule the worker daily at 03:30 UTC.
+-- Supabase's Edge Function gateway requires an Authorization bearer header.
+-- The x-account-deletion-secret header remains the worker's operation-specific
+-- authorization check.
+--
 -- SELECT cron.schedule(
 --   'process-account-deletions',
 --   '30 3 * * *',
 --   $$
 --   SELECT net.http_post(
---     url := '__PROCESS_ACCOUNT_DELETIONS_FUNCTION_URL__',
+--     url := (
+--       SELECT decrypted_secret
+--       FROM vault.decrypted_secrets
+--       WHERE name = 'account_deletion_function_url'
+--     ),
 --     headers := jsonb_build_object(
 --       'Content-Type', 'application/json',
---       'x-account-deletion-secret', '__PROCESS_ACCOUNT_DELETIONS_SECRET__'
+--       'Authorization', 'Bearer ' || (
+--         SELECT decrypted_secret
+--         FROM vault.decrypted_secrets
+--         WHERE name = 'account_deletion_function_bearer'
+--       ),
+--       'x-account-deletion-secret', (
+--         SELECT decrypted_secret
+--         FROM vault.decrypted_secrets
+--         WHERE name = 'account_deletion_worker_secret'
+--       )
 --     ),
---     body := jsonb_build_object('source', 'pg_cron')
+--     body := jsonb_build_object('source', 'pg_cron'),
+--     timeout_milliseconds := 10000
 --   );
 --   $$
 -- );
 
 -- Verification:
--- SELECT jobid, schedule, command
+-- SELECT jobid, jobname, schedule, active, command
 -- FROM cron.job
 -- WHERE jobname = 'process-account-deletions';
 
+-- Smoke test:
+-- SELECT net.http_post(
+--   url := (
+--     SELECT decrypted_secret
+--     FROM vault.decrypted_secrets
+--     WHERE name = 'account_deletion_function_url'
+--   ),
+--   headers := jsonb_build_object(
+--     'Content-Type', 'application/json',
+--     'Authorization', 'Bearer ' || (
+--       SELECT decrypted_secret
+--       FROM vault.decrypted_secrets
+--       WHERE name = 'account_deletion_function_bearer'
+--     ),
+--     'x-account-deletion-secret', (
+--       SELECT decrypted_secret
+--       FROM vault.decrypted_secrets
+--       WHERE name = 'account_deletion_worker_secret'
+--     )
+--   ),
+--   body := jsonb_build_object('source', 'manual_pg_net_smoke'),
+--   timeout_milliseconds := 10000
+-- ) AS request_id;
+--
+-- SELECT id, status_code, content, error_msg, created
+-- FROM net._http_response
+-- WHERE id = <request_id>;
+
 -- Rollback:
--- SELECT cron.unschedule('process-account-deletions');
+-- SELECT cron.unschedule(jobid)
+-- FROM cron.job
+-- WHERE jobname = 'process-account-deletions';

--- a/supabase/account_deletion_schedule.sql
+++ b/supabase/account_deletion_schedule.sql
@@ -1,0 +1,37 @@
+-- Account deletion scheduler setup.
+--
+-- Replace the placeholders below in the live Supabase SQL Editor after the
+-- process-account-deletions Edge Function is deployed and secrets are set.
+-- Do not commit real function URLs or scheduler secrets to the repository.
+
+-- Required extensions in Supabase:
+-- CREATE EXTENSION IF NOT EXISTS pg_cron;
+-- CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Example schedule: every day at 03:30 UTC.
+-- Replace:
+--   __PROCESS_ACCOUNT_DELETIONS_FUNCTION_URL__
+--   __PROCESS_ACCOUNT_DELETIONS_SECRET__
+
+-- SELECT cron.schedule(
+--   'process-account-deletions',
+--   '30 3 * * *',
+--   $$
+--   SELECT net.http_post(
+--     url := '__PROCESS_ACCOUNT_DELETIONS_FUNCTION_URL__',
+--     headers := jsonb_build_object(
+--       'Content-Type', 'application/json',
+--       'x-account-deletion-secret', '__PROCESS_ACCOUNT_DELETIONS_SECRET__'
+--     ),
+--     body := jsonb_build_object('source', 'pg_cron')
+--   );
+--   $$
+-- );
+
+-- Verification:
+-- SELECT jobid, schedule, command
+-- FROM cron.job
+-- WHERE jobname = 'process-account-deletions';
+
+-- Rollback:
+-- SELECT cron.unschedule('process-account-deletions');

--- a/supabase/account_deletion_verification.sql
+++ b/supabase/account_deletion_verification.sql
@@ -183,6 +183,8 @@ END $$;
 DO $$
 DECLARE
   scheduled_job_count integer;
+  scheduled_command text;
+  missing_vault_secrets text[];
 BEGIN
   IF to_regclass('cron.job') IS NULL THEN
     RAISE NOTICE 'cron.job not available in this database session. Verify external scheduler separately if pg_cron is not used.';
@@ -195,6 +197,45 @@ BEGIN
 
   IF scheduled_job_count = 0 THEN
     RAISE NOTICE 'No pg_cron job named process-account-deletions was found. Configure pg_cron or verify the external scheduler before re-enabling offboarding.';
+    RETURN;
+  END IF;
+
+  IF scheduled_job_count > 1 THEN
+    RAISE EXCEPTION 'Account deletion verification failed: multiple pg_cron jobs named process-account-deletions were found.';
+  END IF;
+
+  SELECT command INTO scheduled_command
+  FROM cron.job
+  WHERE jobname = 'process-account-deletions'
+  LIMIT 1;
+
+  IF position('Authorization' IN scheduled_command) = 0
+    OR position('account_deletion_function_bearer' IN scheduled_command) = 0
+    OR position('x-account-deletion-secret' IN scheduled_command) = 0
+    OR position('account_deletion_worker_secret' IN scheduled_command) = 0 THEN
+    RAISE EXCEPTION 'Account deletion verification failed: process-account-deletions cron job is missing required authorization headers.';
+  END IF;
+
+  IF to_regclass('vault.secrets') IS NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: Vault secrets table is unavailable for scheduled worker secrets.';
+  END IF;
+
+  WITH expected(name) AS (
+    VALUES
+      ('account_deletion_function_url'),
+      ('account_deletion_function_bearer'),
+      ('account_deletion_worker_secret')
+  )
+  SELECT array_agg(name ORDER BY name) INTO missing_vault_secrets
+  FROM expected
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM vault.secrets
+    WHERE vault.secrets.name = expected.name
+  );
+
+  IF missing_vault_secrets IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: missing Vault scheduler secrets %.', missing_vault_secrets;
   END IF;
 END $$;
 

--- a/supabase/account_deletion_verification.sql
+++ b/supabase/account_deletion_verification.sql
@@ -1,0 +1,201 @@
+-- Read-only verification after applying add_account_deletion_workflow.sql.
+-- Run in Supabase SQL Editor. Any failure raises an exception.
+
+DO $$
+DECLARE
+  rls_disabled_tables text[];
+  missing_policies text[];
+  unexpected_public_policies text[];
+  direct_client_privileges text[];
+  missing_service_privileges text[];
+  missing_constraints text[];
+BEGIN
+  SELECT array_agg(tablename ORDER BY tablename) INTO rls_disabled_tables
+  FROM pg_tables
+  WHERE schemaname = 'public'
+    AND tablename IN (
+      'account_deletion_requests',
+      'sensitive_action_confirmations',
+      'account_deletion_audit'
+    )
+    AND rowsecurity = false;
+
+  IF rls_disabled_tables IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: RLS disabled on %.', rls_disabled_tables;
+  END IF;
+
+  WITH expected(policyname) AS (
+    VALUES ('account_deletion_requests_select_own')
+  )
+  SELECT array_agg(policyname ORDER BY policyname) INTO missing_policies
+  FROM expected
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND pg_policies.policyname = expected.policyname
+  );
+
+  IF missing_policies IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: missing policies %.', missing_policies;
+  END IF;
+
+  SELECT array_agg(tablename || ':' || policyname ORDER BY tablename, policyname)
+  INTO unexpected_public_policies
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename IN (
+      'account_deletion_requests',
+      'sensitive_action_confirmations',
+      'account_deletion_audit'
+    )
+    AND (
+      array_to_string(roles, ',') = 'public'
+      OR array_to_string(roles, ',') LIKE '%anon%'
+    );
+
+  IF unexpected_public_policies IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: unexpected anon/public table policies %.', unexpected_public_policies;
+  END IF;
+
+  SELECT array_agg(table_name || ':' || privilege_type ORDER BY table_name, privilege_type)
+  INTO direct_client_privileges
+  FROM information_schema.role_table_grants
+  WHERE table_schema = 'public'
+    AND table_name IN (
+      'account_deletion_requests',
+      'sensitive_action_confirmations',
+      'account_deletion_audit'
+    )
+    AND grantee IN ('anon', 'authenticated')
+    AND (
+      table_name <> 'account_deletion_requests'
+      OR privilege_type <> 'SELECT'
+    );
+
+  IF direct_client_privileges IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: unexpected client table grants %.', direct_client_privileges;
+  END IF;
+
+  WITH expected_service_grants(table_name, privilege_type) AS (
+    VALUES
+      ('account_deletion_requests', 'SELECT'),
+      ('sensitive_action_confirmations', 'INSERT'),
+      ('account_deletion_audit', 'INSERT')
+  )
+  SELECT array_agg(table_name || ':' || privilege_type ORDER BY table_name, privilege_type)
+  INTO missing_service_privileges
+  FROM expected_service_grants
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM information_schema.role_table_grants
+    WHERE table_schema = 'public'
+      AND grantee = 'service_role'
+      AND role_table_grants.table_name = expected_service_grants.table_name
+      AND role_table_grants.privilege_type = expected_service_grants.privilege_type
+  );
+
+  IF missing_service_privileges IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: missing service_role table grants %.', missing_service_privileges;
+  END IF;
+
+  IF NOT has_sequence_privilege('service_role', 'public.account_deletion_audit_id_seq', 'USAGE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: service_role cannot use account_deletion_audit_id_seq.';
+  END IF;
+
+  WITH expected_constraints(conname) AS (
+    VALUES
+      ('account_deletion_requests_status_check'),
+      ('account_deletion_requests_release_after_request_check'),
+      ('account_deletion_requests_attempt_count_check'),
+      ('account_deletion_requests_cancelled_shape_check'),
+      ('sensitive_action_confirmations_action_check'),
+      ('sensitive_action_confirmations_method_check'),
+      ('sensitive_action_confirmations_expiry_check'),
+      ('account_deletion_audit_outcome_check')
+  )
+  SELECT array_agg(conname ORDER BY conname) INTO missing_constraints
+  FROM expected_constraints
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE connamespace = 'public'::regnamespace
+      AND pg_constraint.conname = expected_constraints.conname
+      AND convalidated = true
+  );
+
+  IF missing_constraints IS NOT NULL THEN
+    RAISE EXCEPTION 'Account deletion verification failed: missing validated constraints %.', missing_constraints;
+  END IF;
+
+  IF NOT has_function_privilege('authenticated', 'public.request_account_deletion(text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated cannot execute request_account_deletion(text).';
+  END IF;
+
+  IF NOT has_function_privilege('authenticated', 'public.cancel_account_deletion()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated cannot execute cancel_account_deletion().';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.request_account_deletion(text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: anon can execute request_account_deletion(text).';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.cancel_account_deletion()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: anon can execute cancel_account_deletion().';
+  END IF;
+
+  IF has_function_privilege('authenticated', 'public.claim_due_account_deletions(integer, text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated can execute claim_due_account_deletions(integer, text).';
+  END IF;
+
+  IF has_function_privilege('authenticated', 'public.delete_account_app_data(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated can execute delete_account_app_data(uuid).';
+  END IF;
+
+  IF has_function_privilege('authenticated', 'public.mark_account_deletion_failed(uuid, text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated can execute mark_account_deletion_failed(uuid, text).';
+  END IF;
+
+  IF has_function_privilege('authenticated', 'public.mark_account_deletion_skipped_cancelled(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'Account deletion verification failed: authenticated can execute mark_account_deletion_skipped_cancelled(uuid).';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.account_deletion_requests
+    WHERE cancelled_at IS NOT NULL
+      AND status <> 'cancelled'
+  ) THEN
+    RAISE EXCEPTION 'Account deletion verification failed: cancelled request has non-cancelled status.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.account_deletion_requests
+    WHERE cancelled_at IS NOT NULL
+      AND status IN ('pending', 'failed', 'processing')
+      AND release_at <= now()
+  ) THEN
+    RAISE EXCEPTION 'Account deletion verification failed: dry-run due query would include cancelled rows.';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  scheduled_job_count integer;
+BEGIN
+  IF to_regclass('cron.job') IS NULL THEN
+    RAISE NOTICE 'cron.job not available in this database session. Verify external scheduler separately if pg_cron is not used.';
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*) INTO scheduled_job_count
+  FROM cron.job
+  WHERE jobname = 'process-account-deletions';
+
+  IF scheduled_job_count = 0 THEN
+    RAISE NOTICE 'No pg_cron job named process-account-deletions was found. Configure pg_cron or verify the external scheduler before re-enabling offboarding.';
+  END IF;
+END $$;
+
+SELECT 'account_deletion_verification_passed' AS result;

--- a/supabase/functions/confirm-sensitive-action/index.ts
+++ b/supabase/functions/confirm-sensitive-action/index.ts
@@ -8,7 +8,9 @@ const corsHeaders = {
 
 type ConfirmRequest = {
   action?: string;
+  method?: 'password' | 'email_otp_start' | 'email_otp_verify';
   password?: string;
+  otp?: string;
 };
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -45,6 +47,33 @@ async function sha256Hex(value: string): Promise<string> {
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
+async function mintConfirmation(
+  serviceClient: ReturnType<typeof createClient>,
+  userId: string,
+  method: 'password' | 'email_otp'
+) {
+  const confirmationToken = randomToken();
+  const tokenHash = await sha256Hex(confirmationToken);
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+  const { error: insertError } = await serviceClient
+    .from('sensitive_action_confirmations')
+    .insert({
+      user_id: userId,
+      action: 'account_deletion',
+      token_hash: tokenHash,
+      method,
+      expires_at: expiresAt,
+    });
+
+  if (insertError) {
+    console.error('Failed to store sensitive action confirmation', insertError);
+    return { confirmationToken: null, expiresAt: null, error: insertError };
+  }
+
+  return { confirmationToken, expiresAt, error: null };
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -69,10 +98,7 @@ Deno.serve(async (req) => {
     if (body.action !== 'account_deletion') {
       return jsonResponse({ error: 'Unsupported sensitive action' }, 400);
     }
-
-    if (!body.password) {
-      return jsonResponse({ error: 'Password is required' }, 400);
-    }
+    const method = body.method ?? 'password';
 
     const serviceClient = createClient(supabaseUrl, serviceRoleKey, {
       auth: { persistSession: false, autoRefreshToken: false },
@@ -83,22 +109,55 @@ Deno.serve(async (req) => {
       return jsonResponse({ error: 'Authentication required' }, 401);
     }
 
-    const provider = userData.user.app_metadata?.provider;
-    const isOAuthUser =
-      provider === 'google' ||
-      provider === 'github' ||
-      userData.user.identities?.some((identity) => identity.provider !== 'email');
-
-    if (isOAuthUser) {
-      return jsonResponse(
-        { error: 'Account deletion for OAuth accounts requires a verified challenge flow before it can be enabled.' },
-        409
-      );
-    }
-
     const authClient = createClient(supabaseUrl, anonKey, {
       auth: { persistSession: false, autoRefreshToken: false },
     });
+
+    if (method === 'email_otp_start') {
+      const { error: otpError } = await authClient.auth.signInWithOtp({
+        email: userData.user.email,
+        options: {
+          shouldCreateUser: false,
+        },
+      });
+
+      if (otpError) {
+        console.error('Failed to start account deletion email OTP', otpError);
+        return jsonResponse({ error: 'Could not send verification code' }, 500);
+      }
+
+      return jsonResponse({ otpSent: true });
+    }
+
+    if (method === 'email_otp_verify') {
+      if (!body.otp) {
+        return jsonResponse({ error: 'Verification code is required' }, 400);
+      }
+
+      const { data: verifiedData, error: verifyError } = await authClient.auth.verifyOtp({
+        email: userData.user.email,
+        token: body.otp,
+        type: 'email',
+      });
+
+      if (verifyError || verifiedData.user?.id !== userData.user.id) {
+        return jsonResponse({ error: 'Verification failed' }, 401);
+      }
+
+      const confirmation = await mintConfirmation(serviceClient, userData.user.id, 'email_otp');
+      if (confirmation.error || !confirmation.confirmationToken || !confirmation.expiresAt) {
+        return jsonResponse({ error: 'Could not create confirmation' }, 500);
+      }
+
+      return jsonResponse({
+        confirmationToken: confirmation.confirmationToken,
+        expiresAt: confirmation.expiresAt,
+      });
+    }
+
+    if (!body.password) {
+      return jsonResponse({ error: 'Password is required' }, 400);
+    }
 
     const { data: signInData, error: signInError } = await authClient.auth.signInWithPassword({
       email: userData.user.email,
@@ -109,26 +168,15 @@ Deno.serve(async (req) => {
       return jsonResponse({ error: 'Verification failed' }, 401);
     }
 
-    const confirmationToken = randomToken();
-    const tokenHash = await sha256Hex(confirmationToken);
-    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
-
-    const { error: insertError } = await serviceClient
-      .from('sensitive_action_confirmations')
-      .insert({
-        user_id: userData.user.id,
-        action: 'account_deletion',
-        token_hash: tokenHash,
-        method: 'password',
-        expires_at: expiresAt,
-      });
-
-    if (insertError) {
-      console.error('Failed to store sensitive action confirmation', insertError);
+    const confirmation = await mintConfirmation(serviceClient, userData.user.id, 'password');
+    if (confirmation.error || !confirmation.confirmationToken || !confirmation.expiresAt) {
       return jsonResponse({ error: 'Could not create confirmation' }, 500);
     }
 
-    return jsonResponse({ confirmationToken, expiresAt });
+    return jsonResponse({
+      confirmationToken: confirmation.confirmationToken,
+      expiresAt: confirmation.expiresAt,
+    });
   } catch (error) {
     console.error('confirm-sensitive-action failed', error);
     return jsonResponse({ error: 'Unexpected confirmation failure' }, 500);

--- a/supabase/functions/confirm-sensitive-action/index.ts
+++ b/supabase/functions/confirm-sensitive-action/index.ts
@@ -1,0 +1,136 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+type ConfirmRequest = {
+  action?: string;
+  password?: string;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function getEnv(name: string): string {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function base64Url(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function randomToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64Url(bytes);
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    const supabaseUrl = getEnv('SUPABASE_URL');
+    const serviceRoleKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+    const anonKey = getEnv('SUPABASE_ANON_KEY');
+
+    const authorization = req.headers.get('Authorization');
+    const accessToken = authorization?.replace(/^Bearer\s+/i, '');
+    if (!accessToken) {
+      return jsonResponse({ error: 'Authentication required' }, 401);
+    }
+
+    const body = (await req.json()) as ConfirmRequest;
+    if (body.action !== 'account_deletion') {
+      return jsonResponse({ error: 'Unsupported sensitive action' }, 400);
+    }
+
+    if (!body.password) {
+      return jsonResponse({ error: 'Password is required' }, 400);
+    }
+
+    const serviceClient = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { data: userData, error: userError } = await serviceClient.auth.getUser(accessToken);
+    if (userError || !userData.user?.email) {
+      return jsonResponse({ error: 'Authentication required' }, 401);
+    }
+
+    const provider = userData.user.app_metadata?.provider;
+    const isOAuthUser =
+      provider === 'google' ||
+      provider === 'github' ||
+      userData.user.identities?.some((identity) => identity.provider !== 'email');
+
+    if (isOAuthUser) {
+      return jsonResponse(
+        { error: 'Account deletion for OAuth accounts requires a verified challenge flow before it can be enabled.' },
+        409
+      );
+    }
+
+    const authClient = createClient(supabaseUrl, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { data: signInData, error: signInError } = await authClient.auth.signInWithPassword({
+      email: userData.user.email,
+      password: body.password,
+    });
+
+    if (signInError || signInData.user?.id !== userData.user.id) {
+      return jsonResponse({ error: 'Verification failed' }, 401);
+    }
+
+    const confirmationToken = randomToken();
+    const tokenHash = await sha256Hex(confirmationToken);
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+    const { error: insertError } = await serviceClient
+      .from('sensitive_action_confirmations')
+      .insert({
+        user_id: userData.user.id,
+        action: 'account_deletion',
+        token_hash: tokenHash,
+        method: 'password',
+        expires_at: expiresAt,
+      });
+
+    if (insertError) {
+      console.error('Failed to store sensitive action confirmation', insertError);
+      return jsonResponse({ error: 'Could not create confirmation' }, 500);
+    }
+
+    return jsonResponse({ confirmationToken, expiresAt });
+  } catch (error) {
+    console.error('confirm-sensitive-action failed', error);
+    return jsonResponse({ error: 'Unexpected confirmation failure' }, 500);
+  }
+});

--- a/supabase/functions/process-account-deletions/index.ts
+++ b/supabase/functions/process-account-deletions/index.ts
@@ -1,0 +1,184 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-account-deletion-secret',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+type AccountDeletionRequest = {
+  user_id: string;
+  requested_at: string;
+  release_at: string;
+  status: string;
+  cancelled_at: string | null;
+  attempt_count: number;
+  processing_worker_id: string | null;
+};
+
+type SupabaseServiceClient = ReturnType<typeof createClient>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function getEnv(name: string): string {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function audit(
+  client: SupabaseServiceClient,
+  request: AccountDeletionRequest,
+  outcome: string,
+  detail: string | null,
+  workerId: string
+) {
+  const { error } = await client.from('account_deletion_audit').insert({
+    user_id: request.user_id,
+    requested_at: request.requested_at,
+    release_at: request.release_at,
+    attempt_count: request.attempt_count,
+    outcome,
+    detail,
+    worker_id: workerId,
+  });
+
+  if (error) {
+    console.error('Failed to write account deletion audit row', { outcome, error });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+async function markFailed(
+  client: SupabaseServiceClient,
+  request: AccountDeletionRequest,
+  detail: string,
+  workerId: string
+) {
+  const sanitized = detail.slice(0, 1000);
+  const { error } = await client.rpc('mark_account_deletion_failed', {
+    target_user_id: request.user_id,
+    failure_detail: sanitized,
+  });
+
+  if (error) {
+    console.error('Failed to mark account deletion failed', error);
+  }
+
+  await audit(client, request, 'failed', sanitized, workerId);
+}
+
+async function fetchRequest(client: SupabaseServiceClient, userId: string) {
+  return await client
+    .from('account_deletion_requests')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+}
+
+async function processRequest(
+  client: SupabaseServiceClient,
+  request: AccountDeletionRequest,
+  workerId: string
+) {
+  await audit(client, request, 'processing_started', null, workerId);
+
+  try {
+    const { data: beforeDelete, error: beforeDeleteError } = await fetchRequest(client, request.user_id);
+    if (beforeDeleteError) throw beforeDeleteError;
+
+    if (!beforeDelete || beforeDelete.cancelled_at || beforeDelete.status === 'cancelled') {
+      await client.rpc('mark_account_deletion_skipped_cancelled', { target_user_id: request.user_id });
+      await audit(client, request, 'skipped_cancelled', 'Request was cancelled before deletion.', workerId);
+      return { userId: request.user_id, outcome: 'skipped_cancelled' };
+    }
+
+    const { error: appDeleteError } = await client.rpc('delete_account_app_data', {
+      target_user_id: request.user_id,
+    });
+    if (appDeleteError) throw appDeleteError;
+
+    const { data: afterAppDelete, error: afterAppDeleteError } = await fetchRequest(client, request.user_id);
+    if (afterAppDeleteError) throw afterAppDeleteError;
+
+    if (!afterAppDelete || afterAppDelete.cancelled_at || afterAppDelete.status === 'cancelled') {
+      await client.rpc('mark_account_deletion_skipped_cancelled', { target_user_id: request.user_id });
+      await audit(client, request, 'skipped_cancelled', 'Request was cancelled before auth user deletion.', workerId);
+      return { userId: request.user_id, outcome: 'skipped_cancelled' };
+    }
+
+    const { error: authDeleteError } = await client.auth.admin.deleteUser(request.user_id);
+    if (authDeleteError) throw authDeleteError;
+
+    await audit(client, request, 'released', 'App data and auth user deleted.', workerId);
+    return { userId: request.user_id, outcome: 'released' };
+  } catch (error) {
+    const detail = errorMessage(error);
+    await markFailed(client, request, detail, workerId);
+    return { userId: request.user_id, outcome: 'failed', error: detail };
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    const configuredSecret = getEnv('PROCESS_ACCOUNT_DELETIONS_SECRET');
+    const suppliedSecret = req.headers.get('x-account-deletion-secret');
+
+    if (!suppliedSecret || suppliedSecret !== configuredSecret) {
+      return jsonResponse({ error: 'Unauthorized' }, 401);
+    }
+
+    const supabaseUrl = getEnv('SUPABASE_URL');
+    const serviceRoleKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+    const workerId = crypto.randomUUID();
+    const client = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { data: claimed, error: claimError } = await client.rpc('claim_due_account_deletions', {
+      batch_limit: 10,
+      worker_id: workerId,
+    });
+
+    if (claimError) {
+      console.error('Failed to claim due account deletions', claimError);
+      return jsonResponse({ error: 'Could not claim due deletions' }, 500);
+    }
+
+    const results = [];
+    for (const request of (claimed ?? []) as AccountDeletionRequest[]) {
+      results.push(await processRequest(client, request, workerId));
+    }
+
+    return jsonResponse({
+      workerId,
+      claimed: claimed?.length ?? 0,
+      results,
+    });
+  } catch (error) {
+    console.error('process-account-deletions failed', error);
+    return jsonResponse({ error: 'Unexpected account deletion worker failure' }, 500);
+  }
+});

--- a/supabase/migrations/add_account_deletion_workflow.sql
+++ b/supabase/migrations/add_account_deletion_workflow.sql
@@ -1,0 +1,463 @@
+-- Server-owned account deletion workflow.
+--
+-- This intentionally does not re-enable the "Letting Go" UI. It adds the
+-- backend authority, confirmation gate, worker claim path, and audit trail
+-- required before the feature can be safely restored.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+CREATE TABLE IF NOT EXISTS public.account_deletion_requests (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  release_at timestamptz NOT NULL,
+  cancelled_at timestamptz,
+  status text NOT NULL DEFAULT 'pending',
+  attempt_count integer NOT NULL DEFAULT 0,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz,
+  processing_started_at timestamptz,
+  processing_worker_id text,
+  released_at timestamptz,
+  error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT account_deletion_requests_status_check CHECK (
+    status IN ('pending', 'processing', 'cancelled', 'released', 'failed')
+  ),
+  CONSTRAINT account_deletion_requests_release_after_request_check CHECK (
+    release_at >= requested_at
+  ),
+  CONSTRAINT account_deletion_requests_attempt_count_check CHECK (
+    attempt_count >= 0
+  ),
+  CONSTRAINT account_deletion_requests_cancelled_shape_check CHECK (
+    status <> 'cancelled' OR cancelled_at IS NOT NULL
+  )
+);
+
+CREATE TABLE IF NOT EXISTS public.sensitive_action_confirmations (
+  id uuid PRIMARY KEY DEFAULT extensions.gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  action text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  method text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  CONSTRAINT sensitive_action_confirmations_action_check CHECK (
+    action IN ('account_deletion')
+  ),
+  CONSTRAINT sensitive_action_confirmations_method_check CHECK (
+    method IN ('password', 'oauth', 'email_otp')
+  ),
+  CONSTRAINT sensitive_action_confirmations_expiry_check CHECK (
+    expires_at > created_at
+  )
+);
+
+CREATE TABLE IF NOT EXISTS public.account_deletion_audit (
+  id bigserial PRIMARY KEY,
+  user_id uuid,
+  user_id_hash text,
+  requested_at timestamptz,
+  release_at timestamptz,
+  attempt_count integer,
+  outcome text NOT NULL,
+  detail text,
+  worker_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT account_deletion_audit_outcome_check CHECK (
+    outcome IN ('processing_started', 'released', 'failed', 'skipped_cancelled', 'no_op')
+  )
+);
+
+COMMENT ON TABLE public.account_deletion_requests IS
+  'Server-authoritative account deletion requests. Client metadata is not a deletion authority.';
+COMMENT ON TABLE public.sensitive_action_confirmations IS
+  'Short-lived server-verifiable confirmations for sensitive actions such as account deletion.';
+COMMENT ON TABLE public.account_deletion_audit IS
+  'Append-only operational audit for account deletion attempts, failures, skips, and releases.';
+
+ALTER TABLE public.account_deletion_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sensitive_action_confirmations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.account_deletion_audit ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.account_deletion_requests FROM PUBLIC;
+REVOKE ALL ON TABLE public.account_deletion_requests FROM anon;
+REVOKE ALL ON TABLE public.account_deletion_requests FROM authenticated;
+GRANT SELECT ON TABLE public.account_deletion_requests TO authenticated;
+GRANT SELECT ON TABLE public.account_deletion_requests TO service_role;
+
+REVOKE ALL ON TABLE public.sensitive_action_confirmations FROM PUBLIC;
+REVOKE ALL ON TABLE public.sensitive_action_confirmations FROM anon;
+REVOKE ALL ON TABLE public.sensitive_action_confirmations FROM authenticated;
+GRANT INSERT ON TABLE public.sensitive_action_confirmations TO service_role;
+
+REVOKE ALL ON TABLE public.account_deletion_audit FROM PUBLIC;
+REVOKE ALL ON TABLE public.account_deletion_audit FROM anon;
+REVOKE ALL ON TABLE public.account_deletion_audit FROM authenticated;
+GRANT INSERT ON TABLE public.account_deletion_audit TO service_role;
+REVOKE ALL ON SEQUENCE public.account_deletion_audit_id_seq FROM PUBLIC;
+REVOKE ALL ON SEQUENCE public.account_deletion_audit_id_seq FROM anon;
+REVOKE ALL ON SEQUENCE public.account_deletion_audit_id_seq FROM authenticated;
+GRANT USAGE ON SEQUENCE public.account_deletion_audit_id_seq TO service_role;
+
+DROP POLICY IF EXISTS "account_deletion_requests_select_own"
+  ON public.account_deletion_requests;
+
+CREATE POLICY "account_deletion_requests_select_own"
+  ON public.account_deletion_requests FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_account_deletion_requests_due
+  ON public.account_deletion_requests (release_at, next_attempt_at)
+  WHERE status IN ('pending', 'failed', 'processing') AND cancelled_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sensitive_action_confirmations_lookup
+  ON public.sensitive_action_confirmations (user_id, action, token_hash)
+  WHERE consumed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sensitive_action_confirmations_expiry
+  ON public.sensitive_action_confirmations (expires_at)
+  WHERE consumed_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.touch_account_deletion_request_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS account_deletion_requests_touch_updated_at
+  ON public.account_deletion_requests;
+
+CREATE TRIGGER account_deletion_requests_touch_updated_at
+  BEFORE UPDATE ON public.account_deletion_requests
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_account_deletion_request_updated_at();
+
+CREATE OR REPLACE FUNCTION public.request_account_deletion(confirmation_token text)
+RETURNS public.account_deletion_requests
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  calling_user_id uuid := auth.uid();
+  confirmation_id uuid;
+  request_row public.account_deletion_requests;
+  hashed_token text;
+BEGIN
+  IF calling_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to request account deletion.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF confirmation_token IS NULL OR length(confirmation_token) < 32 THEN
+    RAISE EXCEPTION 'Fresh confirmation is required to request account deletion.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  hashed_token := encode(extensions.digest(confirmation_token, 'sha256'), 'hex');
+
+  SELECT id INTO confirmation_id
+  FROM public.sensitive_action_confirmations
+  WHERE user_id = calling_user_id
+    AND action = 'account_deletion'
+    AND token_hash = hashed_token
+    AND consumed_at IS NULL
+    AND expires_at > now()
+  FOR UPDATE;
+
+  IF confirmation_id IS NULL THEN
+    RAISE EXCEPTION 'Fresh confirmation is required to request account deletion.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.sensitive_action_confirmations
+  SET consumed_at = now()
+  WHERE id = confirmation_id;
+
+  INSERT INTO public.account_deletion_requests (
+    user_id,
+    requested_at,
+    release_at,
+    cancelled_at,
+    status,
+    attempt_count,
+    last_attempt_at,
+    next_attempt_at,
+    processing_started_at,
+    processing_worker_id,
+    released_at,
+    error
+  )
+  VALUES (
+    calling_user_id,
+    now(),
+    now() + INTERVAL '14 days',
+    NULL,
+    'pending',
+    0,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  )
+  ON CONFLICT (user_id) DO UPDATE
+  SET requested_at = EXCLUDED.requested_at,
+      release_at = EXCLUDED.release_at,
+      cancelled_at = NULL,
+      status = 'pending',
+      attempt_count = 0,
+      last_attempt_at = NULL,
+      next_attempt_at = NULL,
+      processing_started_at = NULL,
+      processing_worker_id = NULL,
+      released_at = NULL,
+      error = NULL
+  WHERE public.account_deletion_requests.status <> 'processing'
+  RETURNING * INTO request_row;
+
+  IF request_row.user_id IS NULL THEN
+    RAISE EXCEPTION 'Account deletion is already being processed.'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN request_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cancel_account_deletion()
+RETURNS public.account_deletion_requests
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  calling_user_id uuid := auth.uid();
+  request_row public.account_deletion_requests;
+BEGIN
+  IF calling_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to cancel account deletion.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.account_deletion_requests
+  SET cancelled_at = now(),
+      status = 'cancelled',
+      processing_started_at = NULL,
+      processing_worker_id = NULL,
+      next_attempt_at = NULL,
+      error = NULL
+  WHERE user_id = calling_user_id
+    AND status IN ('pending', 'failed', 'processing')
+  RETURNING * INTO request_row;
+
+  IF request_row.user_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN request_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.claim_due_account_deletions(
+  batch_limit integer DEFAULT 10,
+  worker_id text DEFAULT NULL
+)
+RETURNS SETOF public.account_deletion_requests
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  effective_limit integer := LEAST(GREATEST(COALESCE(batch_limit, 10), 1), 50);
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only service_role may claim account deletions.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH due AS (
+    SELECT user_id
+    FROM public.account_deletion_requests
+    WHERE cancelled_at IS NULL
+      AND release_at <= now()
+      AND attempt_count < 10
+      AND (
+        status IN ('pending', 'failed')
+        OR (
+          status = 'processing'
+          AND processing_started_at < now() - INTERVAL '1 hour'
+        )
+      )
+      AND (next_attempt_at IS NULL OR next_attempt_at <= now())
+    ORDER BY release_at ASC
+    LIMIT effective_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.account_deletion_requests adr
+  SET status = 'processing',
+      processing_started_at = now(),
+      processing_worker_id = COALESCE(worker_id, extensions.gen_random_uuid()::text),
+      attempt_count = adr.attempt_count + 1,
+      last_attempt_at = now(),
+      next_attempt_at = NULL,
+      error = NULL
+  FROM due
+  WHERE adr.user_id = due.user_id
+  RETURNING adr.*;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_account_app_data(target_user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only service_role may delete account app data.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.note_shares
+  WHERE user_id = target_user_id;
+
+  DELETE FROM public.note_tags nt
+  WHERE EXISTS (
+    SELECT 1 FROM public.notes n
+    WHERE n.id = nt.note_id
+      AND n.user_id = target_user_id
+  )
+  OR EXISTS (
+    SELECT 1 FROM public.tags t
+    WHERE t.id = nt.tag_id
+      AND t.user_id = target_user_id
+  );
+
+  DELETE FROM public.notes
+  WHERE user_id = target_user_id;
+
+  DELETE FROM public.tags
+  WHERE user_id = target_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_account_deletion_failed(
+  target_user_id uuid,
+  failure_detail text
+)
+RETURNS public.account_deletion_requests
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  request_row public.account_deletion_requests;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only service_role may mark account deletion failures.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.account_deletion_requests
+  SET status = 'failed',
+      error = left(COALESCE(failure_detail, 'Unknown failure'), 1000),
+      processing_started_at = NULL,
+      processing_worker_id = NULL,
+      next_attempt_at = now() + (LEAST(GREATEST(attempt_count, 1), 8) * INTERVAL '15 minutes')
+  WHERE user_id = target_user_id
+  RETURNING * INTO request_row;
+
+  IF request_row.user_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN request_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_account_deletion_skipped_cancelled(
+  target_user_id uuid
+)
+RETURNS public.account_deletion_requests
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  request_row public.account_deletion_requests;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'Only service_role may mark account deletion skips.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.account_deletion_requests
+  SET status = 'cancelled',
+      cancelled_at = COALESCE(cancelled_at, now()),
+      processing_started_at = NULL,
+      processing_worker_id = NULL,
+      next_attempt_at = NULL
+  WHERE user_id = target_user_id
+  RETURNING * INTO request_row;
+
+  IF request_row.user_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN request_row;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.touch_account_deletion_request_updated_at() FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.request_account_deletion(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.request_account_deletion(text) FROM anon;
+REVOKE ALL ON FUNCTION public.request_account_deletion(text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.request_account_deletion(text) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.cancel_account_deletion() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cancel_account_deletion() FROM anon;
+REVOKE ALL ON FUNCTION public.cancel_account_deletion() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_account_deletion() TO authenticated;
+
+REVOKE ALL ON FUNCTION public.claim_due_account_deletions(integer, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.claim_due_account_deletions(integer, text) FROM anon;
+REVOKE ALL ON FUNCTION public.claim_due_account_deletions(integer, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_due_account_deletions(integer, text) TO service_role;
+
+REVOKE ALL ON FUNCTION public.delete_account_app_data(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_account_app_data(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.delete_account_app_data(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_account_app_data(uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.mark_account_deletion_failed(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.mark_account_deletion_failed(uuid, text) FROM anon;
+REVOKE ALL ON FUNCTION public.mark_account_deletion_failed(uuid, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_account_deletion_failed(uuid, text) TO service_role;
+
+REVOKE ALL ON FUNCTION public.mark_account_deletion_skipped_cancelled(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.mark_account_deletion_skipped_cancelled(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.mark_account_deletion_skipped_cancelled(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_account_deletion_skipped_cancelled(uuid) TO service_role;
+
+COMMENT ON FUNCTION public.request_account_deletion(text) IS
+  'Starts the 14-day account deletion grace period after consuming a fresh server-side confirmation token.';
+COMMENT ON FUNCTION public.cancel_account_deletion() IS
+  'Cancels the caller account deletion request if it is still pending, failed, or processing.';
+COMMENT ON FUNCTION public.claim_due_account_deletions(integer, text) IS
+  'Service-only worker claim function for due account deletions using row locking.';
+COMMENT ON FUNCTION public.delete_account_app_data(uuid) IS
+  'Service-only deletion of Yidhan app rows for a user. Auth user deletion remains in the Edge Function Admin API step.';


### PR DESCRIPTION
## Summary
- Add server-owned account deletion schema/RPCs, service-role worker functions, audit trail, schedule template, and verification SQL.
- Rewire offboarding client state away from `user_metadata.departing_at` to `account_deletion_requests` and require a server-minted confirmation token before requesting deletion.
- Replace the fake OAuth typed-email re-auth fallback: email/password users verify by password, while Google/GitHub users receive and verify an email OTP before the deletion token is minted.
- Enable `ACCOUNT_OFFBOARDING_ENABLED` after live production verification, scheduler smoke testing, and a throwaway OAuth account deletion drill passed.
- Update the scheduler template and verification SQL to require the Supabase Edge Function `Authorization` bearer header plus the worker-specific deletion secret.

## Verification
- `npm run check`
- Production Supabase worker smoke test via Vault-backed `pg_net`: HTTP 200, `claimed: 0`
- Production `supabase/account_deletion_verification.sql`: `account_deletion_verification_passed`
- Throwaway Google/OAuth account deletion drill: worker outcome `released`; audit recorded `processing_started` and `released`

## Notes
- `ACCOUNT_OFFBOARDING_ENABLED` is now `true`.
- `REAUTH_FOR_SENSITIVE_ACTIONS` remains `false`; account deletion uses its dedicated password/email-OTP confirmation path.
- No service-role key or scheduler secret is committed.
- Public Privacy/Support deletion copy remains a separate copy/legal review decision.
- Follow-ups left in backlog: custom SMTP or another reliable email path for OAuth OTP volume, and softer post-confirmation UX before logout.
