### PR TITLE
feat: polish landing page and note masonry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ A calm, distraction-free note-taking app — where thoughts bloom with clarity.
 - **Light & Dark Themes** - Kintsugi (warm light) and Midnight (forest green dark) themes
 - **Tag Organization** - Organize notes with colorful tags and filter by multiple tags
 - **Tag Management** - Create, edit, and delete tags with a beautiful color picker
-- **Landing Page** - Quiet hero that becomes a lightweight writing surface on desktop, saves the first draft into signup, and follows with a real-product gallery
+- **Landing Page** - Quiet hero that becomes a lightweight writing surface on desktop, saves the first draft into signup, and leads directly into real note cards and the privacy promise
 - **Practice Space** - Full-featured demo at `/demo` without signup; notes persist in localStorage
 - **Seamless Onboarding** - Demo content auto-saves after signup, email confirmation with resend options
 - **Export/Import** - Backup notes to JSON or Markdown, restore from backups
-- **Rich Card Previews** - Note cards show formatted content (lists, bold, etc.)
+- **Rich Card Previews** - Content-sized masonry cards show formatted previews and center gracefully when a chapter has only one or two notes
 - **Quick Delete** - Delete notes directly from card view with confirmation
 - **Personalized Avatar** - Profile shows your initials from name or email
 - **Settings Page** - Update display name, change password, toggle theme

--- a/docs/ui-layout.md
+++ b/docs/ui-layout.md
@@ -45,16 +45,13 @@ Detailed ASCII diagrams for UI components. Referenced from CLAUDE.md for detaile
 **Gallery second act:**
 ```
 +--------------------------------------------------------------------------+
-| The surface                                                              |
-| A page that gets out of the way.                    [editor surface]      |
-|                                                                          |
 | What accumulates                                                         |
-| [real starter note card masonry]                    Your thoughts...      |
+| Your thoughts, finding their own shape.                                  |
+|                    [real starter note card masonry]                       |
 |                                                                          |
 | What stays yours                                                         |
 | Locked before it leaves your hands.                 [vault mark]          |
-|                                                                          |
-| Your page is waiting.                               [Start writing]       |
+| [Start writing]                                                          |
 | Changelog . Roadmap . GitHub . Privacy . Terms . Support                 |
 +--------------------------------------------------------------------------+
 ```
@@ -83,8 +80,9 @@ Detailed ASCII diagrams for UI components. Referenced from CLAUDE.md for detaile
 - The first typed draft is saved to `yidhan-demo-content` before signup and migrated by `App.tsx` into an encrypted "My first note" after auth/unlock.
 - Hidden hero controls and scroll cue leave the tab order after the editor reveal.
 - Mobile primary CTA routes directly to `/demo` to avoid soft-keyboard viewport shifts.
-- Gallery uses three museum-spaced proof pieces: writing surface, starter-note grid, and encryption/offline/open-source promise.
+- Gallery uses two museum-spaced proof pieces: the starter-note grid followed by the encryption/offline/open-source promise and closing CTA.
 - Gallery starter notes mirror the Practice Space seed notes.
+- Chapters with one or two visible notes cap their masonry columns and center the group; full note cards size to their preview content.
 - Auth opens as modal overlay from `Continue in Yidhan`.
 
 ## Auth Modal (OAuth-First Layout)

--- a/src/components/ChapterSection.tsx
+++ b/src/components/ChapterSection.tsx
@@ -93,6 +93,20 @@ export const ChapterSection = memo(function ChapterSection({
   const hasMore = !isSearching && visibleCount < notes.length;
   const remainingCount = Math.max(0, notes.length - visibleCount);
 
+  // Count-aware masonry: when a chapter holds fewer cards than the viewport's
+  // column count, cap the columns to the card count and centre the group so a
+  // lone card isn't stranded at column 1 of a wide, empty band. At 3+ cards the
+  // full-width 3/2/1 grid is preserved. Widths track the app-true card width
+  // (~440px) plus the 20px masonry gutter.
+  const cardCount = displayNotes.length;
+  const lowCountMaxWidth =
+    cardCount === 1 ? '480px' : cardCount === 2 ? '960px' : undefined;
+  const masonryBreakpoints = {
+    default: Math.min(3, cardCount) || 1,
+    1100: Math.min(2, cardCount) || 1,
+    700: 1,
+  };
+
   // IntersectionObserver for progressive loading
   useEffect(() => {
     if (!sentinelRef.current || isSearching) return;
@@ -277,45 +291,51 @@ export const ChapterSection = memo(function ChapterSection({
           id={`chapter-content-${chapterKey}`}
           style={{ opacity }}
         >
-          <Masonry
-            breakpointCols={{
-              default: 3,
-              1100: 2,
-              700: 1,
-            }}
-            className="masonry-grid px-6 md:px-12"
-            columnClassName="masonry-grid-column"
-          >
-            {displayNotes.map((note, index) => (
-              <div
-                key={note.id}
-                className="note-card-entrance"
-                style={{
-                  animationDelay: `${Math.min(index * 0.06, 0.6)}s`,
-                }}
+          <div className="px-6 md:px-12">
+            <div
+              style={
+                lowCountMaxWidth
+                  ? { maxWidth: lowCountMaxWidth, marginInline: 'auto' }
+                  : undefined
+              }
+            >
+              <Masonry
+                breakpointCols={masonryBreakpoints}
+                className="masonry-grid"
+                columnClassName="masonry-grid-column"
               >
-                {isTouchDevice ? (
-                  <SwipeableNoteCard
-                    note={note}
-                    onClick={onNoteClick}
-                    onDelete={onNoteDelete}
-                    onTogglePin={onTogglePin}
-                    isCompact={isCompact}
-                    searchQuery={isSearching ? searchQuery : undefined}
-                  />
-                ) : (
-                  <NoteCard
-                    note={note}
-                    onClick={onNoteClick}
-                    onDelete={onNoteDelete}
-                    onTogglePin={onTogglePin}
-                    isCompact={isCompact}
-                    searchQuery={isSearching ? searchQuery : undefined}
-                  />
-                )}
-              </div>
-            ))}
-          </Masonry>
+                {displayNotes.map((note, index) => (
+                  <div
+                    key={note.id}
+                    className="note-card-entrance"
+                    style={{
+                      animationDelay: `${Math.min(index * 0.06, 0.6)}s`,
+                    }}
+                  >
+                    {isTouchDevice ? (
+                      <SwipeableNoteCard
+                        note={note}
+                        onClick={onNoteClick}
+                        onDelete={onNoteDelete}
+                        onTogglePin={onTogglePin}
+                        isCompact={isCompact}
+                        searchQuery={isSearching ? searchQuery : undefined}
+                      />
+                    ) : (
+                      <NoteCard
+                        note={note}
+                        onClick={onNoteClick}
+                        onDelete={onNoteDelete}
+                        onTogglePin={onTogglePin}
+                        isCompact={isCompact}
+                        searchQuery={isSearching ? searchQuery : undefined}
+                      />
+                    )}
+                  </div>
+                ))}
+              </Masonry>
+            </div>
+          </div>
 
           {/* Sentinel for IntersectionObserver */}
           {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -236,8 +236,8 @@ export function LandingPage({
               Begin where you <em>are.</em>
             </h1>
             <p className="landing-sub">
-              A quiet space for the half-formed thought. No folders. No organizing.
-              Nothing to learn — just room to think.
+              A quiet space for the half-formed thought.<br />
+              No folders. No organizing. Nothing to learn — just room to think.
             </p>
             <button
               type="button"
@@ -301,7 +301,7 @@ export function LandingPage({
         {!isWriting && (
           <a
             className="landing-scrollcue focus-ring"
-            href="#landing-surface"
+            href="#landing-library"
           >
             <span>Or see how it feels</span>
             <span className="landing-scrollcue-arrow" aria-hidden="true">↓</span>
@@ -311,31 +311,8 @@ export function LandingPage({
 
       {/* ─── Gallery — the honest "second act": the real product ─── */}
       <div className="landing-gallery">
-        {/* The surface */}
-        <section className="landing-piece landing-reveal" id="landing-surface">
-          <div className="landing-caption">
-            <p className="landing-kicker">The surface</p>
-            <h2 className="landing-piece-title">A page that gets out of the way.</h2>
-            <p className="landing-piece-body">
-              No sidebars. No menus crowding the margins. Write in focus mode and the
-              interface recedes — leaving only your words and a soft manuscript glow around
-              the page.
-            </p>
-          </div>
-          <div className="landing-mock-editor" aria-hidden="true">
-            <div className="landing-mock-glow" />
-            <div className="landing-mock-doc">
-              <div className="landing-mock-title">Four Thousand Weeks</div>
-              <p>
-                Started it last night. The bit about how we&rsquo;ll never &ldquo;get on
-                top of everything&rdquo; was oddly freeing.<span className="landing-car" />
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* What accumulates */}
-        <section className="landing-piece-wide">
+        {/* What accumulates — the real product, first beat below the fold */}
+        <section className="landing-piece-wide" id="landing-library">
           <div className="landing-wide-inner landing-reveal">
             <div className="landing-caption">
               <p className="landing-kicker">What accumulates</p>
@@ -369,9 +346,17 @@ export function LandingPage({
             <h2 className="landing-piece-title">Locked before it leaves your hands.</h2>
             <p className="landing-piece-body">
               Every word is encrypted on your device before it syncs — so it reaches your
-              other screens, but never ours readable. It works offline, and the code is open
-              for anyone to check.
+              other screens, but never ours in a form we can read. It works offline, and the
+              code is open for anyone to check.
             </p>
+            <div className="landing-piece-cta">
+              <button type="button" onClick={handleCloseStart} className="landing-cta focus-ring">
+                Start writing
+              </button>
+              <p className="landing-micro">
+                No account needed — your first words stay on this device.
+              </p>
+            </div>
           </div>
           <div className="landing-vault" aria-hidden="true">
             <span className="landing-vault-ring" />
@@ -383,19 +368,6 @@ export function LandingPage({
           </div>
         </section>
       </div>
-
-      {/* ─── Close — echoes the hero ─── */}
-      <section className="landing-close landing-reveal">
-        <h2 className="landing-close-title">
-          Your page is <em>waiting.</em>
-        </h2>
-        <button type="button" onClick={handleCloseStart} className="landing-cta focus-ring">
-          Start writing
-        </button>
-        <p className="landing-micro">
-          No account needed — your first words stay on this device.
-        </p>
-      </section>
 
       {/* ─── Footer nav ─── */}
       <nav className="landing-footer">
@@ -503,7 +475,7 @@ export function LandingPage({
           font-size: 1.1rem;
           line-height: 1.7;
           color: var(--color-text-secondary);
-          max-width: 40ch;
+          max-width: 38rem;
           margin: 0 auto 2.4rem;
         }
         .landing-cta {
@@ -536,7 +508,7 @@ export function LandingPage({
           gap: 0.3rem;
           margin-top: 1.6rem;
           font-family: var(--font-body);
-          font-size: 0.82rem;
+          font-size: 0.92rem;
           color: var(--color-text-tertiary);
           text-decoration: none;
           border-bottom: 1px dotted var(--color-text-tertiary);
@@ -597,7 +569,7 @@ export function LandingPage({
         .landing-hero-doc::placeholder {
           color: var(--color-text-tertiary);
           font-style: italic;
-          font-weight: 300;
+          font-weight: 400;
           opacity: 1;
         }
         .landing-hero-foot {
@@ -607,14 +579,14 @@ export function LandingPage({
         }
         .landing-seal {
           font-family: var(--font-body);
-          font-size: 0.72rem; letter-spacing: 0.04em;
+          font-size: 0.82rem; letter-spacing: 0.04em;
           color: var(--color-text-tertiary);
           display: inline-flex; align-items: center; gap: 0.5rem;
           opacity: 0; transform: translateY(4px);
           transition: opacity 0.6s ease, transform 0.6s ease;
         }
         .landing-seal-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); }
-        .landing-seal.show { opacity: 0.9; transform: none; }
+        .landing-seal.show { opacity: 1; transform: none; }
         .landing-continue {
           font-family: var(--font-body);
           font-size: 0.8rem;
@@ -646,16 +618,16 @@ export function LandingPage({
         .landing-hero.writing .landing-scrollcue { opacity: 0; pointer-events: none; }
 
         .landing-scrollcue {
-          position: absolute; left: 50%; bottom: 2.2rem; transform: translateX(-50%);
+          position: absolute; left: 0; right: 0; bottom: 2.2rem;
+          margin-inline: auto; width: max-content;
           display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
           font-family: var(--font-body);
-          font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.18em;
+          font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.18em;
           color: var(--color-text-tertiary); text-decoration: none;
-          animation: landing-float 3.4s ease-in-out infinite;
           transition: opacity 0.5s ease;
         }
         .landing-scrollcue:hover { color: var(--color-accent); }
-        .landing-scrollcue-arrow { font-size: 1rem; }
+        .landing-scrollcue-arrow { font-size: 1rem; animation: landing-float 3.4s ease-in-out infinite; }
 
         /* ─── Gallery ─── */
         .landing-gallery {
@@ -677,7 +649,7 @@ export function LandingPage({
         }
         .landing-kicker {
           font-family: var(--font-body);
-          font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.18em;
+          font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.18em;
           color: var(--color-accent); margin: 0 0 1rem;
         }
         .landing-piece-title {
@@ -691,32 +663,6 @@ export function LandingPage({
           color: var(--color-text-secondary); max-width: 42ch; margin: 0;
         }
 
-        /* Surface mock editor */
-        .landing-mock-editor {
-          position: relative;
-          background: var(--color-bg-primary);
-          border: 1px solid var(--glass-border);
-          border-radius: var(--radius-card);
-          box-shadow: var(--shadow-manuscript);
-          padding: clamp(2rem, 4vw, 3.2rem);
-          overflow: hidden;
-        }
-        .landing-mock-glow {
-          position: absolute; inset: 0; pointer-events: none;
-          background: radial-gradient(ellipse 80% 50% at 50% 36%, var(--color-accent-glow) 0%, transparent 70%);
-        }
-        .landing-mock-doc { position: relative; z-index: 1; }
-        .landing-mock-title {
-          font-family: var(--font-display); font-weight: 600;
-          font-size: 1.9rem; line-height: 1.3; letter-spacing: 0;
-          color: var(--color-text-primary); margin-bottom: 0.8rem;
-        }
-        .landing-mock-doc p {
-          font-family: var(--font-body); font-weight: 400;
-          font-size: 1.16rem; line-height: 1.85;
-          color: var(--color-text-primary); margin: 0;
-        }
-
         /* Note grid - rendered with the real NoteCard in decorative mode */
         /* "What accumulates" steps out of the editorial 2-col split: a centered
            caption above a centered 2-up masonry. Cards render at app-true width
@@ -725,10 +671,10 @@ export function LandingPage({
         .landing-piece-wide { margin-bottom: clamp(6rem, 16vw, 13rem); }
         .landing-piece-wide .landing-caption {
           text-align: center;
-          max-width: 48ch;
+          max-width: 48rem;
           margin: 0 auto clamp(2.5rem, 5vw, 3.5rem);
         }
-        .landing-piece-wide .landing-piece-body { margin-left: auto; margin-right: auto; }
+        .landing-piece-wide .landing-piece-body { max-width: 34rem; margin-left: auto; margin-right: auto; }
         .landing-grid {
           columns: 2;
           column-gap: 1.5rem;
@@ -751,17 +697,8 @@ export function LandingPage({
           border: 1px dashed color-mix(in srgb, var(--color-accent) 40%, transparent);
         }
 
-        /* ─── Close ─── */
-        .landing-close {
-          text-align: center;
-          padding: clamp(5rem, 14vw, 11rem) 1.4rem clamp(3rem, 8vw, 6rem);
-        }
-        .landing-close-title {
-          font-family: var(--font-display); font-weight: 300;
-          font-size: 3.4rem; line-height: 1.06;
-          margin: 0 0 2.2rem; color: var(--color-text-primary);
-        }
-        .landing-close-title em { font-style: italic; color: var(--color-accent); font-weight: 400; }
+        /* Inline CTA closing the encryption piece (replaces the old standalone close beat) */
+        .landing-piece-cta { margin-top: 2.2rem; }
 
         /* ─── Footer ─── */
         .landing-footer {
@@ -783,14 +720,7 @@ export function LandingPage({
         .landing-reveal { opacity: 0; transform: translateY(26px); transition: opacity 0.9s ease, transform 0.9s cubic-bezier(0.22,1,0.36,1); }
         .landing-reveal.in { opacity: 1; transform: none; }
 
-        .landing-car {
-          display: inline-block; width: 2px; height: 1.05em; vertical-align: -0.16em;
-          margin-left: 0.1em; border-radius: 1px; background: var(--color-accent);
-          animation: landing-blink 2.6s ease-in-out infinite;
-        }
-
-        @keyframes landing-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.2; } }
-        @keyframes landing-float { 0%, 100% { transform: translate(-50%, 0); } 50% { transform: translate(-50%, 6px); } }
+        @keyframes landing-float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(6px); } }
         @keyframes landing-fade-up { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
 
         @media (max-width: 768px) {
@@ -800,22 +730,20 @@ export function LandingPage({
           .landing-headline { font-size: 3.2rem; }
           .landing-sub { font-size: 1rem; }
           .landing-piece-title { font-size: 2.2rem; }
-          .landing-close-title { font-size: 2.6rem; }
         }
 
         @media (max-width: 420px) {
           .landing-headline { font-size: 2.75rem; }
           .landing-piece-title { font-size: 2rem; }
-          .landing-close-title { font-size: 2.3rem; }
         }
 
         @media (prefers-reduced-motion: reduce) {
           .landing-prose,
           .landing-hero-editor-wrap,
           .landing-scrollcue,
+          .landing-scrollcue-arrow,
           .landing-seal,
           .landing-continue,
-          .landing-car,
           .landing-reveal { animation: none !important; transition: none !important; }
           .landing-reveal { opacity: 1; transform: none; }
         }

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -104,8 +104,10 @@ export const NoteCard = memo(function NoteCard({
         borderRadius: 'var(--radius-card)',
         boxShadow: isCompact ? 'var(--shadow-sm)' : 'var(--shadow-md)',
         transitionTimingFunction: 'var(--ease-out-quint)',
-        minHeight: isCompact ? 'auto' : '280px',
-        maxHeight: isCompact ? '120px' : '300px',
+        // Full cards size to their content so the masonry actually staggers;
+        // the preview caps its own height below. Compact keeps a fixed clamp.
+        minHeight: isCompact ? 'auto' : undefined,
+        maxHeight: isCompact ? '120px' : undefined,
       }}
       onMouseEnter={(e) => {
         if (!isCompact && !isDecorative) {
@@ -208,10 +210,12 @@ export const NoteCard = memo(function NoteCard({
         </p>
       ) : (
         <div
-          className="flex-1 overflow-hidden note-card-preview"
+          className="overflow-hidden note-card-preview"
           style={{
             fontFamily: 'var(--font-body)',
             color: 'var(--color-text-secondary)',
+            // Content-driven height up to ~5 lines; the bottom mask fades the cut.
+            maxHeight: '8em',
           }}
           dangerouslySetInnerHTML={{ __html: htmlPreview || 'No content' }}
         />

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,6 +8,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '3.19.5',
+    date: '2026-08-09',
+    changes: [
+      { type: 'improvement', text: 'Note chapters now center one- and two-card groups, while content-driven card heights restore the natural masonry rhythm' },
+      { type: 'improvement', text: 'Landing page now reaches the real note library sooner, closes with its privacy promise and writing CTA, and uses clearer supporting copy' },
+      { type: 'improvement', text: 'Paper texture is lighter across every theme so small and low-contrast text stays crisp' },
+    ],
+  },
+  {
     version: '3.19.4',
     date: '2026-06-23',
     changes: [

--- a/src/index.css
+++ b/src/index.css
@@ -41,7 +41,7 @@
   --shadow-sm: 0 2px 8px rgba(120, 80, 60, 0.18);
   --shadow-md: 0 4px 12px rgba(120, 80, 60, 0.12), 0 20px 40px -10px rgba(120, 80, 60, 0.38);
   --shadow-lg: 0 4px 12px rgba(120, 80, 60, 0.15), 0 10px 40px rgba(120, 80, 60, 0.38);
-  --noise-opacity: 0.11;
+  --noise-opacity: 0.055;
   --noise-filter: sepia(65%) saturate(140%) brightness(0.93);
 }
 
@@ -77,7 +77,7 @@
   --shadow-sm: 0 2px 8px rgba(5, 20, 10, 0.4);
   --shadow-md: 0 4px 12px rgba(5, 20, 10, 0.2), 0 10px 40px -10px rgba(5, 20, 10, 0.55);
   --shadow-lg: 0 4px 12px rgba(5, 20, 10, 0.25), 0 20px 50px -10px rgba(5, 20, 10, 0.65);
-  --noise-opacity: 0.05;
+  --noise-opacity: 0.04;
   --noise-filter: grayscale(100%);
 }
 /* THEME-END */

--- a/src/themes/kintsugi.ts
+++ b/src/themes/kintsugi.ts
@@ -59,7 +59,7 @@ const kintsugi: ThemeConfig = {
     shadowLg: '0 4px 12px rgba(120, 80, 60, 0.15), 0 10px 40px rgba(120, 80, 60, 0.38)',
 
     // Effects
-    noiseOpacity: '0.18',
+    noiseOpacity: '0.055', // Lowered from 0.18 — heavy grain over content blurred small/low-contrast text
     noiseFilter: 'sepia(65%) saturate(140%) brightness(0.93)', // Warmer, more defined grain
   },
 };

--- a/src/themes/midnight.ts
+++ b/src/themes/midnight.ts
@@ -59,7 +59,7 @@ const midnight: ThemeConfig = {
     shadowLg: '0 4px 12px rgba(5, 20, 10, 0.25), 0 20px 50px -10px rgba(5, 20, 10, 0.65)',
 
     // Effects
-    noiseOpacity: '0.05',
+    noiseOpacity: '0.04', // Lowered from 0.05 to keep small text crisp under the texture overlay
     noiseFilter: 'grayscale(100%)', // Neutral grain for dark mode
   },
 };

--- a/src/themes/mori.ts
+++ b/src/themes/mori.ts
@@ -61,7 +61,7 @@ const mori: ThemeConfig = {
     shadowLg: '0 20px 50px -10px rgba(0, 0, 0, 0.55)',
 
     // Effects
-    noiseOpacity: '0.10',
+    noiseOpacity: '0.05', // Lowered from 0.10 to keep small text crisp under the texture overlay
     noiseFilter: 'grayscale(100%)', // Neutral grain for dark mode
   },
 };

--- a/src/themes/washi.ts
+++ b/src/themes/washi.ts
@@ -61,7 +61,7 @@ const washi: ThemeConfig = {
     shadowLg: '0 4px 12px rgba(61, 54, 48, 0.10), 0 10px 40px rgba(61, 54, 48, 0.25)',
 
     // Effects
-    noiseOpacity: '0.10',
+    noiseOpacity: '0.05', // Lowered from 0.10 to keep small text crisp under the texture overlay
     noiseFilter: 'sepia(80%) saturate(120%) brightness(0.95)', // Warm aged paper tint
   },
 };


### PR DESCRIPTION
Summary: centers low-count note chapters, restores content-driven masonry card heights, simplifies the landing-page second act, and reduces theme texture for crisper text. Documentation and changelog are updated. Validation: typecheck, lint, 942 unit tests, coverage, and production build passed. Targeted browser E2E was skipped at user request after local Playwright browser setup issues.